### PR TITLE
Refactor shared chart and KPI grouping helpers

### DIFF
--- a/scripts/core.js
+++ b/scripts/core.js
@@ -160,6 +160,146 @@ function calculateGroupValues(group, dataset) {
   return { country: group.title || group.id, value: val, year };
 }
 
+// === Deep merge helper (for Chart option overrides) ===
+function deepMerge(target, ...sources) {
+  if (!target) target = {};
+  for (const src of sources) {
+    if (!src || typeof src !== "object") continue;
+    for (const [key, value] of Object.entries(src)) {
+      if (
+        value &&
+        typeof value === "object" &&
+        !Array.isArray(value) &&
+        typeof target[key] === "object" &&
+        !Array.isArray(target[key])
+      ) {
+        deepMerge(target[key], value);
+      } else {
+        target[key] = value;
+      }
+    }
+  }
+  return target;
+}
+
+// === Shared KPI cluster grouping ===
+function groupKpisByCluster(list, options = {}) {
+  const {
+    filter,
+    mapItem,
+    sortClusters = true,
+    itemSorter
+  } = options;
+
+  if (!Array.isArray(list)) return [];
+
+  const clusters = new Map();
+  for (const meta of list) {
+    if (filter && !filter(meta)) continue;
+    const clusterName = meta?.cluster || "Other";
+    if (!clusters.has(clusterName)) clusters.set(clusterName, []);
+    clusters.get(clusterName).push(mapItem ? mapItem(meta) : meta);
+  }
+
+  const entries = Array.from(clusters.entries());
+  if (sortClusters) entries.sort((a, b) => a[0].localeCompare(b[0]));
+
+  for (const [, items] of entries) {
+    if (typeof itemSorter === "function") {
+      items.sort(itemSorter);
+    } else {
+      items.sort((a, b) => {
+        const aKey = (a?.title || a?.label || a?.id || "").toString();
+        const bKey = (b?.title || b?.label || b?.id || "").toString();
+        return aKey.localeCompare(bKey);
+      });
+    }
+  }
+
+  return entries;
+}
+
+// === Shared Chart.js renderer ===
+function renderLineChart(canvas, config = {}) {
+  if (!canvas || typeof canvas.getContext !== "function") return null;
+
+  const {
+    labels = [],
+    datasets = [],
+    title = "",
+    unit = "",
+    existingChart = null,
+    fallbackDataset = null,
+    options = {}
+  } = config;
+
+  if (existingChart?.destroy) existingChart.destroy();
+
+  const safeLabels = labels.length ? labels : [0, 1, 2];
+  const baseFallback = fallbackDataset || {
+    label: "No data available",
+    data: safeLabels.map(() => null),
+    borderColor: "rgba(180,180,180,0.5)",
+    borderWidth: 1,
+    pointRadius: 0,
+    fill: false
+  };
+
+  const configObj = {
+    type: "line",
+    data: {
+      labels: safeLabels,
+      datasets: datasets.length ? datasets : [baseFallback]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: "nearest", intersect: false },
+      layout: { padding: { top: 16, bottom: 12, left: 8, right: 8 } },
+      plugins: {
+        title: { display: !!title, text: title },
+        legend: { display: datasets.length > 0 },
+        tooltip: {
+          enabled: true,
+          callbacks: {
+            title: ctx =>
+              ctx?.length ? `Year: ${ctx[0].label ?? ""}` : "",
+            label: ctx => {
+              const datasetLabel = ctx.dataset?.label
+                ? `${ctx.dataset.label}: `
+                : "";
+              const value = ctx.parsed?.y;
+              if (value == null || isNaN(value)) {
+                return `${datasetLabel}no data`;
+              }
+              const formatted = Number(value).toLocaleString();
+              return unit
+                ? `${datasetLabel}${formatted} ${unit}`.trim()
+                : `${datasetLabel}${formatted}`;
+            }
+          }
+        }
+      },
+      scales: {
+        y: {
+          beginAtZero: true,
+          title: { display: !!unit, text: unit || "" },
+          grid: { color: "rgba(0,0,0,0.1)" }
+        },
+        x: {
+          ticks: { autoSkip: true, maxTicksLimit: 12 },
+          grid: { color: "rgba(0,0,0,0.05)" }
+        }
+      }
+    }
+  };
+
+  deepMerge(configObj.options, options);
+
+  const ctx = canvas.getContext("2d");
+  return new Chart(ctx, configObj);
+}
+
 // === Simple console logging helper ===
 function rcLog(...msg) {
   console.log("🧭 RealityCheck:", ...msg);
@@ -299,8 +439,10 @@ window.showSpinner = showSpinner;
 window.normalizeName = normalizeName;
 window.resolveCountryName = resolveCountryName;
 window.calculateGroupValues = calculateGroupValues;
+window.groupKpisByCluster = groupKpisByCluster;
 window.rcLog = rcLog;
 window.loadAllKPIData = loadAllKPIData;
+window.renderLineChart = renderLineChart;
 window.loadKpiAnalysis = loadKpiAnalysis;
 window.renderKpiAnalysis = renderKpiAnalysis;
 

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -146,42 +146,52 @@ async function populateKpiSelect() {
   sel.disabled = true;
   sel.innerHTML = "<option>Loading KPIs…</option>";
 
-  const clusters = {};
-  const tmp = [];
+  const optgroups = [];
 
   try {
-    for (const meta of getKpiArray().filter(k => k.world_kpi !== "e")) {
-      const id = meta.filename;
-      const cl = meta.cluster || "Other";
-      if (!clusters[cl]) clusters[cl] = [];
-      clusters[cl].push({ id, title: meta.title, relation: meta.relation });
-    }
-
-		for (const cl of Object.keys(clusters).sort()) {
-			const g = document.createElement("optgroup");
-			g.label = cl;
-
-			for (const it of clusters[cl].sort((a, b) => a.title.localeCompare(b.title))) {
-				const o = document.createElement("option");
-				o.value = it.id;
-				o.textContent = it.title;
-
-				// ⚡ Schneller: Prüfe nur lokal im ALL_DATA-Cache
-				if (!ALL_DATA[it.id] || !Array.isArray(ALL_DATA[it.id]) || !ALL_DATA[it.id].length) {
-					o.style.color = "gray";
-					o.style.fontStyle = "italic";
-				}
-
-				g.appendChild(o);
-			}
-
-			tmp.push(g);
-		}
+    const grouped = groupKpisByCluster(getKpiArray(), {
+      filter: k => k.world_kpi !== "e",
+      mapItem: meta => ({
+        id: meta.filename,
+        title: meta.title || meta.filename || "Unnamed KPI"
+      })
+    });
 
     sel.innerHTML = "<option value=''>-- none --</option>";
-    tmp.forEach(g => sel.appendChild(g));
+
+    grouped.forEach(([clusterName, list]) => {
+      const g = document.createElement("optgroup");
+      g.label = clusterName;
+
+      list.forEach(item => {
+        if (!item?.id) return;
+        const o = document.createElement("option");
+        o.value = item.id;
+        o.textContent = item.title;
+
+        if (
+          !ALL_DATA[item.id] ||
+          !Array.isArray(ALL_DATA[item.id]) ||
+          !ALL_DATA[item.id].length
+        ) {
+          o.style.color = "gray";
+          o.style.fontStyle = "italic";
+        }
+
+        g.appendChild(o);
+      });
+
+      optgroups.push(g);
+    });
+
+    if (!optgroups.length) {
+      sel.innerHTML = "<option value=''>No KPIs available</option>";
+    } else {
+      optgroups.forEach(g => sel.appendChild(g));
+    }
   } catch (e) {
     console.error("populateKpiSelect() failed:", e);
+    sel.innerHTML = "<option value=''>Failed to load KPIs</option>";
   } finally {
     sel.classList.remove("loading");
     sel.disabled = false;
@@ -712,69 +722,52 @@ function updateChart() {
     });
   });
 
-  const ctx = ctxEl.getContext("2d");
-  if (chartInstance) chartInstance.destroy();
+  const fallbackLabels = years.length ? years : [0, 1, 2];
 
-  // 💡 Chart.js mit Tooltip, Responsive, World-Styling
-  chartInstance = new Chart(ctx, {
-    type: "line",
-    data: {
-      labels: years.length ? years : [0, 1, 2],
-      datasets:
-        datasets.length > 0
-          ? datasets
-          : [
-              {
-                label: "Select countries to display data",
-                data: [null, null, null],
-                borderColor: "rgba(200,200,200,0.3)",
-                borderWidth: 1,
-                fill: false
-              }
-            ]
+  chartInstance = renderLineChart(ctxEl, {
+    labels: years,
+    datasets,
+    title: meta.title || "No data selected",
+    unit: meta.unit || "",
+    existingChart: chartInstance,
+    fallbackDataset: {
+      label: "Select countries to display data",
+      data: fallbackLabels.map(() => null),
+      borderColor: "rgba(200,200,200,0.3)",
+      borderWidth: 1,
+      fill: false
     },
     options: {
-      responsive: true,
-      maintainAspectRatio: false, // ✅ Responsive Höhe durch css
-	  aspectRatio: 2, // stabilisiert Höhe-Breite-Verhältnis
+      maintainAspectRatio: false,
+      aspectRatio: 2,
       layout: {
         padding: { top: 20, bottom: 10, left: 10, right: 10 }
       },
       plugins: {
-        title: { 
-          display: true, 
-          text: meta.title || "No data selected" 
-        },
-        legend: { 
-          display: datasets.length > 0 
-        },
+        title: { text: meta.title || "No data selected" },
+        legend: { display: datasets.length > 0 },
         tooltip: {
-          enabled: true,
           callbacks: {
-            label: function(ctx) {
-              const country = ctx.dataset.label || '';
+            label: ctx => {
+              const country = ctx.dataset.label || "";
               const year = ctx.label;
-              const value = ctx.parsed.y;
-              if (value == null || isNaN(value)) return `${country}: no data (${year})`;
+              const value = ctx.parsed?.y;
+              if (value == null || isNaN(value)) {
+                return `${country}: no data (${year})`;
+              }
               return `${country}: ${value.toLocaleString()} (${year})`;
             },
-            title: function(ctx) {
-              return "Year: " + (ctx[0]?.label ?? "");
-            }
+            title: ctx => "Year: " + (ctx[0]?.label ?? "")
           }
         }
       },
-      interaction: {
-        mode: 'nearest',
-        intersect: false
-      },
       scales: {
-        y: { 
-          beginAtZero: true, 
-          title: { display: true, text: meta.unit || "" },
+        y: {
+          beginAtZero: true,
+          title: { display: !!(meta.unit || ""), text: meta.unit || "" },
           grid: { color: "rgba(255,255,255,0.05)" }
         },
-        x: { 
+        x: {
           grid: { color: "rgba(255,255,255,0.05)" }
         }
       }

--- a/scripts/script_overall_ranking_countries.js
+++ b/scripts/script_overall_ranking_countries.js
@@ -112,49 +112,41 @@ function buildRelevanceControls() {
   const container = document.getElementById("priority-container");
   container.innerHTML = "";
 
-  const clusters = {};
-  kpis
-    .filter(
-      k =>
-        ["higher", "lower", "target"].includes(k.sort) &&
-        k.world_kpi !== "e" &&
-        (k.relevance ?? "normal") !== "none"
-    )
-    .forEach(meta => {
-      const cl = meta.cluster || "Other";
-      if (!clusters[cl]) clusters[cl] = [];
-      clusters[cl].push(meta);
-    });
+  const relevantGroups = groupKpisByCluster(kpis, {
+    filter: k =>
+      ["higher", "lower", "target"].includes(k.sort) &&
+      k.world_kpi !== "e" &&
+      (k.relevance ?? "normal") !== "none",
+    itemSorter: (a, b) => (a.title || "").localeCompare(b.title || "")
+  });
 
-  for (const [clusterName, list] of Object.entries(clusters)) {
+  for (const [clusterName, list] of relevantGroups) {
     const group = document.createElement("div");
     group.className = "cluster-box";
     const h3 = document.createElement("h3");
     h3.textContent = clusterName;
     group.appendChild(h3);
 
-    list
-      .sort((a, b) => a.title.localeCompare(b.title))
-      .forEach(meta => {
-        const row = document.createElement("div");
-        row.className = "kpi-row";
-        const label = document.createElement("label");
-        label.textContent = meta.title + ": ";
+    list.forEach(meta => {
+      const row = document.createElement("div");
+      row.className = "kpi-row";
+      const label = document.createElement("label");
+      label.textContent = meta.title + ": ";
 
-        const sel = document.createElement("select");
-        ["very_high", "high", "normal", "low", "irrelevant"].forEach(opt => {
-          const o = document.createElement("option");
-          o.value = opt;
-          o.textContent = opt.replace("_", " ");
-          if (opt === (meta.relevance || "normal")) o.selected = true;
-          sel.appendChild(o);
-        });
-
-        sel.dataset.kpi = meta.filename;
-        row.appendChild(label);
-        row.appendChild(sel);
-        group.appendChild(row);
+      const sel = document.createElement("select");
+      ["very_high", "high", "normal", "low", "irrelevant"].forEach(opt => {
+        const o = document.createElement("option");
+        o.value = opt;
+        o.textContent = opt.replace("_", " ");
+        if (opt === (meta.relevance || "normal")) o.selected = true;
+        sel.appendChild(o);
       });
+
+      sel.dataset.kpi = meta.filename;
+      row.appendChild(label);
+      row.appendChild(sel);
+      group.appendChild(row);
+    });
 
     container.appendChild(group);
   }

--- a/scripts/script_world.js
+++ b/scripts/script_world.js
@@ -34,12 +34,10 @@ function renderChart(container, title, unit, data) {
   canvas.style.marginBottom = "1rem";
   canvas.style.background = "#fff";
 
-  const ctx = canvas.getContext("2d");
-  new Chart(ctx, {
-    type: "line",
-    data: {
-      labels: data.years,
-      datasets: [{
+  renderLineChart(canvas, {
+    labels: data.years,
+    datasets: [
+      {
         label: title,
         data: data.values,
         borderColor: "#1a355e",
@@ -48,11 +46,11 @@ function renderChart(container, title, unit, data) {
         pointHoverRadius: 5,
         fill: false,
         tension: 0.25
-      }]
-    },
+      }
+    ],
+    unit,
+    title: "",
     options: {
-      responsive: true,
-      interaction: { mode: "nearest", intersect: false },
       plugins: {
         title: { display: false },
         legend: { display: false },
@@ -61,7 +59,7 @@ function renderChart(container, title, unit, data) {
           callbacks: {
             title: ctx => "Year: " + (ctx[0]?.label ?? ""),
             label: ctx => {
-              const val = ctx.parsed.y;
+              const val = ctx.parsed?.y;
               if (val == null || isNaN(val)) return "No data";
               return `${val.toLocaleString()} ${unit || ""}`.trim();
             }


### PR DESCRIPTION
## Summary
- add reusable Chart.js renderer and KPI cluster grouping helpers to `core.js`
- refactor the dashboard chart and world KPIs to consume the shared renderer
- reuse the KPI grouping helper for relevance controls on the overall ranking page

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915bfa9a8ec832da8a66913f20ff87c)