### PR TITLE
Remove iframe detection scripts and defer world assets

### DIFF
--- a/overall_ranking_countries.html
+++ b/overall_ranking_countries.html
@@ -5,19 +5,6 @@
   <title>RealityCheck – Overall Country Ranking</title>
   <link rel="stylesheet" href="style.css">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <script>
-document.addEventListener("DOMContentLoaded", () => {
-  try {
-    if (window.self !== window.top) {
-      document.body.classList.add("in-iframe");
-    } else {
-      document.body.classList.remove("in-iframe");
-    }
-  } catch(e) {
-    console.warn("iframe detection failed", e);
-  }
-});
-</script>
 
 </head>
 
@@ -87,9 +74,9 @@ document.addEventListener("DOMContentLoaded", () => {
 </section>
 
   <!-- JS -->
-  <script src="https://cdn.jsdelivr.net/npm/pako@2.1.0/dist/pako.min.js"></script>
-	<!-- 🧠 Shared RealityCheck Core -->
-	<script src="scripts/core.js" defer></script>
-  <script src="scripts/script_overall_ranking_countries.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/pako@2.1.0/dist/pako.min.js" defer></script>
+        <!-- 🧠 Shared RealityCheck Core -->
+        <script src="scripts/core.js" defer></script>
+  <script src="scripts/script_overall_ranking_countries.js" defer></script>
 </body>
 </html>

--- a/world.html
+++ b/world.html
@@ -7,21 +7,7 @@
   <title>RealityCheck – World Trends Dashboard</title>
 
   <link rel="stylesheet" href="style.css" />
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-
-  <script>
-  document.addEventListener("DOMContentLoaded", () => {
-    try {
-      if (window.self !== window.top) {
-        document.body.classList.add("in-iframe");
-      } else {
-        document.body.classList.remove("in-iframe");
-      }
-    } catch(e) {
-      console.warn("iframe detection failed", e);
-    }
-  });
-  </script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
 </head>
 
 <body class="world-page">
@@ -59,9 +45,9 @@
   </p>
 
   <!-- JS -->
-  <script src="https://cdn.jsdelivr.net/npm/pako@2.1.0/dist/pako.min.js"></script>
-	<!-- 🧠 Shared RealityCheck Core -->
-	<script src="scripts/core.js" defer></script>
-  <script src="scripts/script_world.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/pako@2.1.0/dist/pako.min.js" defer></script>
+        <!-- 🧠 Shared RealityCheck Core -->
+        <script src="scripts/core.js" defer></script>
+  <script src="scripts/script_world.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the unused iframe detection snippets from the world and overall ranking dashboards
- load Chart.js, pako, and the dashboard bundles with `defer` so they no longer block rendering

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915e2ce6e30832db516c96a83571659)