### PR TITLE
Streamline shared helpers and HTML initialization

### DIFF
--- a/data_glossary.html
+++ b/data_glossary.html
@@ -17,19 +17,6 @@
     th.sort-desc::after { content: " ↓"; color: #007bff; }
   </style>
 
-  <script>
-  document.addEventListener("DOMContentLoaded", () => {
-    try {
-      if (window.self !== window.top) {
-        document.body.classList.add("in-iframe");
-      } else {
-        document.body.classList.remove("in-iframe");
-      }
-    } catch(e) {
-      console.warn("iframe detection failed", e);
-    }
-  });
-  </script>
 </head>
 
 <body class="glossary-page">
@@ -75,28 +62,9 @@
   </section>
 
   <!-- gzip support -->
-  <script src="https://cdn.jsdelivr.net/npm/pako@2.1.0/dist/pako.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/pako@2.1.0/dist/pako.min.js" defer></script>
 
   <script>
-  async function loadAllKPIData() {
-    const ALL = {};
-    const parts = [1, 2, 3, 4];
-    for (const i of parts) {
-      const url = `data/all_kpis_part${i}.json.gz`;
-      try {
-        const resp = await fetch(url, { cache: "no-store" });
-        if (!resp.ok) continue;
-        const buf = await resp.arrayBuffer();
-        const text = new TextDecoder().decode(pako.ungzip(buf));
-        Object.assign(ALL, JSON.parse(text));
-        console.log(`✅ Loaded ${url}`);
-      } catch (e) {
-        console.warn(`⚠️ Could not load ${url}`, e);
-      }
-    }
-    return ALL;
-  }
-
   async function loadGlossary() {
     try {
       const [fetchRes, outlierRes, metaRes, countryRes] = await Promise.all([
@@ -233,7 +201,11 @@
     rows.forEach(r => tbody.appendChild(r));
   }
 
-  window.addEventListener("DOMContentLoaded", loadGlossary);
+  if (typeof onDocumentReady === "function") {
+    onDocumentReady(loadGlossary);
+  } else {
+    window.addEventListener("DOMContentLoaded", loadGlossary);
+  }
   </script>
 
   <script src="scripts/core.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=countries.html">
   <script>window.location.replace('countries.html');</script>
 </head>
 <body>

--- a/overall_ranking_countries.html
+++ b/overall_ranking_countries.html
@@ -5,19 +5,6 @@
   <title>RealityCheck – Overall Country Ranking</title>
   <link rel="stylesheet" href="style.css">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <script>
-document.addEventListener("DOMContentLoaded", () => {
-  try {
-    if (window.self !== window.top) {
-      document.body.classList.add("in-iframe");
-    } else {
-      document.body.classList.remove("in-iframe");
-    }
-  } catch(e) {
-    console.warn("iframe detection failed", e);
-  }
-});
-</script>
 
 </head>
 
@@ -87,9 +74,9 @@ document.addEventListener("DOMContentLoaded", () => {
 </section>
 
   <!-- JS -->
-  <script src="https://cdn.jsdelivr.net/npm/pako@2.1.0/dist/pako.min.js"></script>
-	<!-- 🧠 Shared RealityCheck Core -->
-	<script src="scripts/core.js" defer></script>
-  <script src="scripts/script_overall_ranking_countries.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/pako@2.1.0/dist/pako.min.js" defer></script>
+        <!-- 🧠 Shared RealityCheck Core -->
+        <script src="scripts/core.js" defer></script>
+  <script src="scripts/script_overall_ranking_countries.js" defer></script>
 </body>
 </html>

--- a/scripts/core.js
+++ b/scripts/core.js
@@ -90,6 +90,25 @@ async function loadJSON(path) {
   }
 }
 
+// === DOM ready helpers (promise + callback) ===
+function whenDocumentReady() {
+  if (document.readyState === "complete" || document.readyState === "interactive") {
+    return Promise.resolve();
+  }
+  return new Promise(resolve =>
+    document.addEventListener("DOMContentLoaded", resolve, { once: true })
+  );
+}
+
+function onDocumentReady(handler) {
+  if (typeof handler !== "function") return;
+  if (document.readyState === "complete" || document.readyState === "interactive") {
+    handler();
+  } else {
+    document.addEventListener("DOMContentLoaded", handler, { once: true });
+  }
+}
+
 // === Spinner (zentriert + fade) ===
 function showSpinner(show = true, msg = "Loading…") {
   const sp = document.getElementById("overlay-spinner");
@@ -158,6 +177,46 @@ function calculateGroupValues(group, dataset) {
     : records.reduce((a, r) => a + (r.value || 0), 0);
   const year = Math.max(...records.map(r => r.year || 0));
   return { country: group.title || group.id, value: val, year };
+}
+
+// === Shared number helpers ===
+function chooseScaleFromValues(values = []) {
+  const numbers = Array.isArray(values) ? values : [];
+  const maxValue = numbers.reduce((max, value) => {
+    const numeric = value == null ? 0 : Math.abs(Number(value));
+    return numeric > max ? numeric : max;
+  }, 0);
+
+  if (maxValue >= 1e9) return { factor: 1e9, suffix: "B", label: "Billions" };
+  if (maxValue >= 1e6) return { factor: 1e6, suffix: "M", label: "Millions" };
+  if (maxValue >= 1e3) return { factor: 1e3, suffix: "K", label: "Thousands" };
+  return { factor: 1, suffix: "", label: "Exact values" };
+}
+
+function formatValueAuto(value, scaleMode = "auto") {
+  if (value === null || value === undefined || Number.isNaN(value)) return "-";
+  const abs = Math.abs(Number(value));
+
+  if (scaleMode === "%" || scaleMode === "none" || scaleMode === "index") {
+    return Number(value).toFixed(2);
+  }
+
+  if (scaleMode === "auto") {
+    if (abs >= 1e12) return (value / 1e12).toFixed(2) + " T";
+    if (abs >= 1e9) return (value / 1e9).toFixed(2) + " B";
+    if (abs >= 1e6) return (value / 1e6).toFixed(2) + " M";
+    if (abs >= 1e3) return (value / 1e3).toFixed(2) + " K";
+    return Number(value).toFixed(2);
+  }
+
+  return Number(value).toFixed(2);
+}
+
+function calcTrend(current, previous) {
+  if (current == null || previous == null) return "→";
+  if (current > previous) return "↑";
+  if (current < previous) return "↓";
+  return "→";
 }
 
 // === Deep merge helper (for Chart option overrides) ===
@@ -453,10 +512,15 @@ async function renderKpiAnalysis(metaOrId, targetId = "kpi-analysis") {
 // === Expose globally for non-module pages ===
 window.loadJSON = loadJSON;
 window.showSpinner = showSpinner;
+window.whenDocumentReady = whenDocumentReady;
+window.onDocumentReady = onDocumentReady;
 window.normalizeName = normalizeName;
 window.resolveCountryName = resolveCountryName;
 window.calculateGroupValues = calculateGroupValues;
 window.groupKpisByCluster = groupKpisByCluster;
+window.chooseScaleFromValues = chooseScaleFromValues;
+window.formatValueAuto = formatValueAuto;
+window.calcTrend = calcTrend;
 window.rcLog = rcLog;
 window.loadAllKPIData = loadAllKPIData;
 window.renderLineChart = renderLineChart;

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -11,43 +11,13 @@ let userSort = { col: null, asc: false };
 let currentScale = { factor: 1, suffix: "", label: "Exact values" };
 let sortingBound = false;
 
-/* ========= Frame Loader ========= */
-function loadFrame(page) {
-  const frame = document.getElementById("main-frame");
-  if (frame) frame.src = page;
-}
-
 /* ========= Helpers ========= */
-function chooseScaleFromValues(v) {
-  const m = Math.max(0, ...v.map(x => (x == null ? 0 : Math.abs(x))));
-  if (m >= 1e9) return { factor: 1e9, suffix: "B", label: "Billions" };
-  if (m >= 1e6) return { factor: 1e6, suffix: "M", label: "Millions" };
-  if (m >= 1e3) return { factor: 1e3, suffix: "K", label: "Thousands" };
-  return { factor: 1, suffix: "", label: "Exact values" };
-}
-function formatValueAuto(value, scaleMode = "auto") {
-  if (value === null || value === undefined || isNaN(value)) return "-";
-  const abs = Math.abs(value);
-  if (scaleMode === "%" || scaleMode === "none" || scaleMode === "index")
-    return value.toFixed(2);
-  if (scaleMode === "auto") {
-    if (abs >= 1e12) return (value / 1e12).toFixed(2) + " T";
-    if (abs >= 1e9) return (value / 1e9).toFixed(2) + " B";
-    if (abs >= 1e6) return (value / 1e6).toFixed(2) + " M";
-    if (abs >= 1e3) return (value / 1e3).toFixed(2) + " K";
-    return value.toFixed(2);
-  }
-  return value.toFixed(2);
-}
+// chooseScaleFromValues, formatValueAuto und calcTrend kommen aus scripts/core.js
 function formatWithScale(v) {
   return v == null || isNaN(v)
     ? "-"
     : (v / currentScale.factor).toFixed(2) +
         (currentScale.suffix ? " " + currentScale.suffix : "");
-}
-function calcTrend(a, b) {
-  if (a == null || b == null) return "→";
-  return a > b ? "↑" : a < b ? "↓" : "→";
 }
 function getKpiArray() {
   return Array.isArray(kpis)
@@ -60,13 +30,7 @@ function getKpiArray() {
 /* ========= Init ========= */
 async function init() {
   try {
-    if (
-      document.readyState !== "complete" &&
-      document.readyState !== "interactive"
-    )
-      await new Promise(r =>
-        document.addEventListener("DOMContentLoaded", r, { once: true })
-      );
+    await whenDocumentReady();
 
     if (!document.getElementById("kpiSelect")) {
       console.warn("RealityCheck: #kpiSelect not found -- skipping init.");
@@ -1210,7 +1174,7 @@ window.updateMap = updateMap;
 window.highlightOnMap = highlightOnMap;
 
 /* ========= MAP AUTO-INIT (Retry Logic for Leaflet) ========= */
-window.addEventListener("DOMContentLoaded", async () => {
+onDocumentReady(async () => {
   for (let tries = 1; tries <= 5; tries++) {
     const mapEl = document.getElementById("map");
     if (mapEl && mapEl.offsetHeight > 0 && typeof L !== "undefined") {
@@ -1226,37 +1190,5 @@ window.addEventListener("DOMContentLoaded", async () => {
 
 
 /* ========= Start ========= */
-document.addEventListener("DOMContentLoaded", () => init());
+onDocumentReady(() => init());
 
-// =====================================================
-// 🔁 loadPage() for navigation (used in index.html <nav>)
-// =====================================================
-function loadPage(page, link) {
-  const frame = document.getElementById("main-frame");
-  const loader = document.getElementById("frame-loader");
-
-  if (!frame) {
-    console.warn("⚠️ main-frame element not found!");
-    return;
-  }
-
-  // Loader aktivieren
-  if (loader) loader.classList.add("active");
-
-  // Seite neu laden (mit Cache-Bypass)
-  frame.src = page + "?t=" + Date.now();
-
-  // Aktiven Menüpunkt markieren
-  document.querySelectorAll("nav a").forEach(a => a.classList.remove("active"));
-  if (link) link.classList.add("active");
-
-  // Wenn Frame fertig geladen ist → Loader ausblenden
-  frame.addEventListener(
-    "load",
-    () => loader && loader.classList.remove("active"),
-    { once: true }
-  );
-}
-
-// Damit onclick="loadPage(...)" im HTML funktioniert
-window.loadPage = loadPage;

--- a/scripts/script_overall_ranking_countries.js
+++ b/scripts/script_overall_ranking_countries.js
@@ -103,7 +103,11 @@ function initModeSwitch() {
   });
 }
 
-document.addEventListener("DOMContentLoaded", initModeSwitch);
+if (typeof onDocumentReady === "function") {
+  onDocumentReady(initModeSwitch);
+} else {
+  document.addEventListener("DOMContentLoaded", initModeSwitch);
+}
 
 
 
@@ -538,4 +542,8 @@ async function fetchLastUpdated() {
 }
 
 /* ---------- Start ---------- */
-window.addEventListener("DOMContentLoaded", initOverall);
+if (typeof onDocumentReady === "function") {
+  onDocumentReady(initOverall);
+} else {
+  window.addEventListener("DOMContentLoaded", initOverall);
+}

--- a/scripts/script_world.js
+++ b/scripts/script_world.js
@@ -265,4 +265,8 @@ async function initWorldPage() {
 }
 
 // === Seite initialisieren ===
-document.addEventListener("DOMContentLoaded", initWorldPage);
+if (typeof onDocumentReady === "function") {
+  onDocumentReady(initWorldPage);
+} else {
+  document.addEventListener("DOMContentLoaded", initWorldPage);
+}

--- a/world.html
+++ b/world.html
@@ -7,21 +7,7 @@
   <title>RealityCheck – World Trends Dashboard</title>
 
   <link rel="stylesheet" href="style.css" />
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-
-  <script>
-  document.addEventListener("DOMContentLoaded", () => {
-    try {
-      if (window.self !== window.top) {
-        document.body.classList.add("in-iframe");
-      } else {
-        document.body.classList.remove("in-iframe");
-      }
-    } catch(e) {
-      console.warn("iframe detection failed", e);
-    }
-  });
-  </script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
 </head>
 
 <body class="world-page">
@@ -59,9 +45,9 @@
   </p>
 
   <!-- JS -->
-  <script src="https://cdn.jsdelivr.net/npm/pako@2.1.0/dist/pako.min.js"></script>
-	<!-- 🧠 Shared RealityCheck Core -->
-	<script src="scripts/core.js" defer></script>
-  <script src="scripts/script_world.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/pako@2.1.0/dist/pako.min.js" defer></script>
+        <!-- 🧠 Shared RealityCheck Core -->
+        <script src="scripts/core.js" defer></script>
+  <script src="scripts/script_world.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add DOM-ready helpers and shared number formatting utilities to the global core bundle
- refactor the dashboard scripts to reuse the shared helpers instead of duplicating logic
- simplify supporting HTML pages by deferring heavy scripts and removing redundant inline blocks

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915e2ce6e30832db516c96a83571659)