### PR TITLE
Refine legend styling across pages

### DIFF
--- a/countries.html
+++ b/countries.html
@@ -17,7 +17,7 @@
 
 </head>
 
-<body>
+<body class="countries-page">
 	<!-- Header wird automatisch über core.js geladen -->
   <!-- 🔝 Sprungmarke für Scroll-to-Top -->
   <a id="page-top"></a>

--- a/data_glossary.html
+++ b/data_glossary.html
@@ -6,16 +6,6 @@
   <title>RealityCheck – Data Glossary</title>
 
   <link rel="stylesheet" href="style.css" />
-  <style>
-    th.sortable { cursor: pointer; user-select: none; }
-    th.sortable::after {
-      content: " ⇅";
-      font-size: 0.8em;
-      color: #999;
-    }
-    th.sort-asc::after  { content: " ↑"; color: #007bff; }
-    th.sort-desc::after { content: " ↓"; color: #007bff; }
-  </style>
 
 </head>
 

--- a/scripts/script_overall_ranking_countries.js
+++ b/scripts/script_overall_ranking_countries.js
@@ -427,7 +427,7 @@ function renderLegend(prioritizedCount, missing = []) {
       <p>
         For each KPI the <b>latest country value</b> is normalized to <code>[0,1]</code>:
       </p>
-      <pre style="background:#0b1220;color:#e6e9ef;padding:.6rem;border-radius:.4rem;line-height:1.4;overflow:auto;">
+      <pre class="legend-code">
 norm = (value - min) / (max - min)
 if sort == "lower": norm = 1 - norm
 weighted = norm × relevance_weight

--- a/style.css
+++ b/style.css
@@ -97,7 +97,7 @@ body, html {
 #map {
   width: 100%;
   max-width: 900px;
-  height: 520px !important;
+  height: 360px !important;
   margin: 0 auto;
   display: block;
 }
@@ -175,14 +175,112 @@ tr.flop10 { background: #ff6f61 !important; color: #fff; }
 
 #legend { max-width: var(--max-width); margin: 1.5rem auto 2rem; padding: 0 2vw; font-size: .9em; color: var(--legend); }
 
+body.countries-page #legend {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.2rem 1.5rem;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+}
+
+body.countries-page #legend h3 { margin-bottom: 0.75rem; }
+
+body.countries-page #legend ul {
+  list-style: disc inside;
+  line-height: 1.55;
+  padding-left: 0;
+  margin: 0;
+}
+
+body.countries-page #legend li { margin-bottom: 0.35rem; }
+
+body.glossary-page #legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 0.6rem 1.2rem;
+  text-align: center;
+}
+
+body.glossary-page #legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 500;
+  padding: 0.25rem 0.6rem;
+}
+
+body.glossary-page #legend span:not(.outlier) {
+  border-radius: 999px;
+}
+
+body.overall-page #legend {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 2.5rem;
+}
+
+@media (min-width: 880px) {
+  body.overall-page #legend {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+body.overall-page #legend .legend-block {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 10px 28px rgba(0,0,0,0.08);
+  line-height: 1.55;
+}
+
+body.overall-page #legend .legend-block h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
+body.overall-page #legend .legend-block p { margin: 0.45rem 0; }
+
+body.overall-page #legend .legend-block ul {
+  margin: 0.8rem 0;
+  padding-left: 1.2rem;
+}
+
+body.overall-page #legend .legend-block li { margin-bottom: 0.35rem; }
+
+body.overall-page #legend .legend-code {
+  background: #0b1220;
+  color: #e6e9ef;
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.4rem;
+  line-height: 1.4;
+  overflow: auto;
+  font-family: "Fira Code", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.9rem;
+}
+
+body.overall-page #legend .missing-kpis {
+  margin-top: 1rem;
+  background: rgba(255,215,0,0.1);
+  border-left: 4px solid #f0c419;
+  border-radius: 6px;
+  padding: 0.6rem 0.8rem;
+}
+
+body.overall-page #legend .missing-kpis span {
+  display: inline-block;
+  margin-top: 0.35rem;
+  font-size: 0.9rem;
+  color: #333;
+}
+
 
 #data-meta { text-align: center; font-size: .85em; color: #666; margin: -.5rem 0 1.5rem; }
 
 
 #data-meta a { color: #0b63c5; }
-
-
-  #map { height: 360px !important; }
 
 
 #world-intro { max-width: 900px; margin: 2rem auto 3rem; text-align: center; line-height: 1.6; padding: 0 1rem; }
@@ -1927,4 +2025,25 @@ Fixes: header/menu overflow, footer overflow, disappearing icons
     max-width: 160px;                  /* mobil kompakter */
     font-size: 0.8rem;
   }
+}
+
+body.glossary-page th.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+
+body.glossary-page th.sortable::after {
+  content: " ⇅";
+  font-size: 0.8em;
+  color: #999;
+}
+
+body.glossary-page th.sort-asc::after {
+  content: " ↑";
+  color: #007bff;
+}
+
+body.glossary-page th.sort-desc::after {
+  content: " ↓";
+  color: #007bff;
 }


### PR DESCRIPTION
## Summary
- move the glossary table sorting cues from inline styles into `style.css`
- scope legend styling for the countries, glossary, and overall ranking pages within the shared stylesheet
- clean up redundant map height declarations while keeping the latest value

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915fc344b78832dbde475554105375b)