### PR TITLE
Use translator icon button with English consent text

### DIFF
--- a/header.html
+++ b/header.html
@@ -1,13 +1,43 @@
 <header id="main-header">
-  <a href="countries.html" id="logo-link">
-    <img id="logo" src="images/logo.png" alt="RealityCheck Logo">
-    <span id="logo-text">RealityCheck</span>
-  </a>
+  <div class="header-branding">
+    <a href="countries.html" id="logo-link">
+      <img id="logo" src="images/logo.png" alt="RealityCheck Logo">
+      <span id="logo-text">RealityCheck</span>
+    </a>
+  </div>
 
-  <nav>
-    <a href="countries.html">Countries</a>
-    <a href="world.html">World</a>
-    <a href="overall_ranking_countries.html">Overall Ranking</a>
-    <a href="analysis.html">Analysis</a>    
-  </nav>
+  <div class="header-actions">
+    <nav aria-label="Primary">
+      <a href="countries.html">Countries</a>
+      <a href="world.html">World</a>
+      <a href="overall_ranking_countries.html">Overall Ranking</a>
+      <a href="analysis.html">Analysis</a>
+    </nav>
+
+    <div class="translator-launcher">
+      <button
+        type="button"
+        id="translator-toggle"
+        class="translator-button"
+        title="Translator"
+        aria-haspopup="dialog"
+        aria-controls="translator-panel"
+        aria-expanded="false"
+      >
+        <span class="sr-only">Translator</span>
+        <img src="images/translate.png" alt="" class="translator-icon" aria-hidden="true">
+      </button>
+
+      <div id="translator-panel" class="translator-panel" role="region" aria-label="Google Translate" hidden>
+        <div class="translator-panel-header">
+          <span>Google Translate</span>
+          <button type="button" class="translator-close" aria-label="Close translator" title="Close">&times;</button>
+        </div>
+        <div class="translator-panel-body">
+          <p class="translator-loading-message">Google Translate is loading…</p>
+          <div id="google_translate_element" class="translator-widget"></div>
+        </div>
+      </div>
+    </div>
+  </div>
 </header>

--- a/privacy.html
+++ b/privacy.html
@@ -57,8 +57,19 @@
       RealityCheck itself does not perform any tracking or store personal information from these services.
     </p>
 
+    <h3>🌐 Optional translation feature (Google Translate)</h3>
     <p>
-      You have the right to request access to any data stored about you and request its deletion at any time.  
+      If you choose to translate the content, we load <strong>Google Translate</strong> on demand.
+      The service only starts after you give explicit consent; without your approval no data is transmitted to Google.
+    </p>
+    <p>
+      Your choice is stored for the current session in <code>sessionStorage</code>,
+      so that subsequent pages can be translated automatically.
+      You can stop the translation at any time by closing the dialog or reloading the page.
+    </p>
+
+    <p>
+      You have the right to request access to any data stored about you and request its deletion at any time.
       Contact: <a href="mailto:realitycheck.cw@gmail.com">realitycheck.cw@gmail.com</a>
     </p>
 	

--- a/scripts/core.js
+++ b/scripts/core.js
@@ -2,6 +2,27 @@
    🌍 RealityCheck – Shared Header & Footer Loader (no iframes)
    ============================================================ */
 
+const TRANSLATOR_SESSION_KEY = "rc_google_translate_consent";
+const translatorState = {
+  button: null,
+  panel: null,
+  closeBtn: null,
+  overlay: null,
+  dialog: null,
+  confirmBtn: null,
+  cancelBtn: null,
+  consent: false,
+  previousFocus: null,
+  scriptPromise: null,
+  ready: false,
+  pendingOpen: false,
+  initialized: false,
+  listenersAttached: false
+};
+
+let translatorInitResolve;
+let translatorInitReject;
+
 document.addEventListener("DOMContentLoaded", async () => {
   try {
     // === Header laden ===
@@ -16,6 +37,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     header.querySelectorAll("nav a").forEach(a => {
       if (a.getAttribute("href") === current) a.classList.add("active");
     });
+
+    setupTranslatorControls();
 
     // === Footer laden ===
     const footerRes = await fetch("footer.html?t=" + Date.now());
@@ -55,6 +78,259 @@ document.addEventListener("DOMContentLoaded", async () => {
     console.warn("⚠️ Header/Footer load failed:", err);
   }
 });
+function setupTranslatorControls() {
+  if (translatorState.initialized) return;
+
+  const button = document.getElementById("translator-toggle");
+  const panel = document.getElementById("translator-panel");
+  if (!button || !panel) return;
+
+  translatorState.button = button;
+  translatorState.panel = panel;
+  translatorState.closeBtn = panel.querySelector(".translator-close");
+  translatorState.initialized = true;
+
+  button.addEventListener("click", handleTranslatorButtonClick);
+  button.setAttribute("aria-expanded", "false");
+
+  translatorState.closeBtn?.addEventListener("click", event => {
+    event.preventDefault();
+    hideTranslatorPanel();
+    translatorState.button?.focus();
+  });
+
+  panel.addEventListener("click", event => event.stopPropagation());
+
+  if (!translatorState.listenersAttached) {
+    document.addEventListener("click", handleTranslatorDocumentClick);
+    document.addEventListener("keydown", handleTranslatorKeydown, true);
+    translatorState.listenersAttached = true;
+  }
+
+  createTranslatorConsentOverlay();
+
+  translatorState.consent = sessionStorage.getItem(TRANSLATOR_SESSION_KEY) === "true";
+
+  if (translatorState.consent) {
+    ensureGoogleTranslate().catch(err => {
+      console.warn("⚠️ Google Translate could not be loaded:", err);
+      updateTranslatorMessage("Google Translate could not be loaded.");
+    });
+  }
+}
+
+function handleTranslatorButtonClick(event) {
+  event.preventDefault();
+  event.stopPropagation();
+
+  if (!translatorState.consent) {
+    openTranslatorConsentDialog();
+    return;
+  }
+
+  if (!translatorState.ready) {
+    translatorState.pendingOpen = true;
+    showTranslatorPanel();
+    ensureGoogleTranslate().catch(err => {
+      console.warn("⚠️ Google Translate could not be loaded:", err);
+      updateTranslatorMessage("Google Translate could not be loaded.");
+      translatorState.pendingOpen = false;
+    });
+    return;
+  }
+
+  if (translatorState.panel.hidden) {
+    showTranslatorPanel();
+  } else {
+    hideTranslatorPanel();
+  }
+}
+
+function handleTranslatorDocumentClick(event) {
+  if (!translatorState.panel || translatorState.panel.hidden) return;
+  if (translatorState.button && event.target === translatorState.button) return;
+  if (translatorState.panel.contains(event.target)) return;
+  hideTranslatorPanel();
+}
+
+function handleTranslatorKeydown(event) {
+  if (event.key !== "Escape") return;
+
+  if (translatorState.overlay && !translatorState.overlay.hidden) {
+    closeTranslatorConsentDialog();
+    event.stopPropagation();
+    event.preventDefault();
+    return;
+  }
+
+  if (translatorState.panel && !translatorState.panel.hidden) {
+    hideTranslatorPanel();
+    event.stopPropagation();
+    event.preventDefault();
+  }
+}
+
+function showTranslatorPanel() {
+  if (!translatorState.panel) return;
+  translatorState.panel.hidden = false;
+  translatorState.button?.setAttribute("aria-expanded", "true");
+}
+
+function hideTranslatorPanel() {
+  if (!translatorState.panel) return;
+  translatorState.panel.hidden = true;
+  translatorState.button?.setAttribute("aria-expanded", "false");
+  translatorState.pendingOpen = false;
+}
+
+function createTranslatorConsentOverlay() {
+  if (translatorState.overlay) return;
+
+  const overlay = document.createElement("div");
+  overlay.id = "translator-consent-overlay";
+  overlay.className = "translator-consent-overlay";
+  overlay.hidden = true;
+  overlay.setAttribute("role", "dialog");
+  overlay.setAttribute("aria-modal", "true");
+  overlay.setAttribute("aria-labelledby", "translator-consent-title");
+  overlay.innerHTML = `
+    <div class="translator-consent-dialog" tabindex="-1">
+      <h2 id="translator-consent-title">Activate Google Translate</h2>
+      <p>We offer an optional translation feature powered by Google Translate. A connection to Google is only established after you confirm.</p>
+      <p class="translator-consent-note">Without your consent, no data is sent to Google. Your decision applies to this session and can be withdrawn at any time.</p>
+      <div class="translator-consent-actions">
+        <button type="button" class="translator-consent-cancel" id="translator-consent-cancel">Cancel</button>
+        <button type="button" class="translator-consent-accept" id="translator-consent-accept">Agree – launch Google Translate</button>
+      </div>
+    </div>
+  `;
+
+  document.body.appendChild(overlay);
+
+  translatorState.overlay = overlay;
+  translatorState.dialog = overlay.querySelector(".translator-consent-dialog");
+  translatorState.confirmBtn = overlay.querySelector("#translator-consent-accept");
+  translatorState.cancelBtn = overlay.querySelector("#translator-consent-cancel");
+
+  translatorState.dialog?.addEventListener("click", event => event.stopPropagation());
+  translatorState.confirmBtn?.addEventListener("click", confirmTranslatorConsent);
+  translatorState.cancelBtn?.addEventListener("click", closeTranslatorConsentDialog);
+  overlay.addEventListener("click", event => {
+    if (event.target === overlay) {
+      closeTranslatorConsentDialog();
+    }
+  });
+}
+
+function openTranslatorConsentDialog() {
+  if (!translatorState.overlay) createTranslatorConsentOverlay();
+  hideTranslatorPanel();
+  translatorState.previousFocus = document.activeElement;
+  translatorState.overlay.hidden = false;
+
+  requestAnimationFrame(() => {
+    translatorState.confirmBtn?.focus();
+  });
+}
+
+function closeTranslatorConsentDialog() {
+  if (!translatorState.overlay) return;
+  translatorState.overlay.hidden = true;
+  if (translatorState.previousFocus && typeof translatorState.previousFocus.focus === "function") {
+    translatorState.previousFocus.focus();
+  } else {
+    translatorState.button?.focus();
+  }
+  translatorState.previousFocus = null;
+}
+
+function confirmTranslatorConsent() {
+  translatorState.consent = true;
+  sessionStorage.setItem(TRANSLATOR_SESSION_KEY, "true");
+  closeTranslatorConsentDialog();
+  translatorState.pendingOpen = true;
+  showTranslatorPanel();
+  ensureGoogleTranslate().catch(err => {
+    console.warn("⚠️ Google Translate could not be loaded:", err);
+    updateTranslatorMessage("Google Translate could not be loaded.");
+    translatorState.pendingOpen = false;
+  });
+}
+
+function ensureGoogleTranslate() {
+  if (translatorState.ready) return Promise.resolve();
+  if (translatorState.scriptPromise) return translatorState.scriptPromise;
+
+  updateTranslatorMessage("Google Translate is loading…");
+
+  translatorState.scriptPromise = new Promise((resolve, reject) => {
+    translatorInitResolve = resolve;
+    translatorInitReject = reject;
+
+    const script = document.createElement("script");
+    script.src = "https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit";
+    script.async = true;
+    script.onerror = () => {
+      script.remove();
+      translatorInitResolve = null;
+      translatorInitReject = null;
+      translatorState.scriptPromise = null;
+      updateTranslatorMessage("Google Translate could not be loaded.");
+      reject(new Error("Google Translate script failed to load."));
+    };
+    document.head.appendChild(script);
+  });
+
+  return translatorState.scriptPromise;
+}
+
+function updateTranslatorMessage(message) {
+  const msgEl = document.querySelector(".translator-loading-message");
+  if (!msgEl) return;
+  msgEl.textContent = message;
+  msgEl.hidden = false;
+}
+
+window.googleTranslateElementInit = function googleTranslateElementInit() {
+  try {
+    const pageLanguage = document.documentElement.lang || "en";
+    const layout = google.translate?.TranslateElement?.InlineLayout?.SIMPLE;
+    new google.translate.TranslateElement({
+      pageLanguage,
+      includedLanguages: "de,en,es,fr",
+      layout: layout ?? undefined,
+      autoDisplay: false
+    }, "google_translate_element");
+
+    translatorState.ready = true;
+    translatorState.scriptPromise = Promise.resolve();
+
+    const msgEl = document.querySelector(".translator-loading-message");
+    if (msgEl) msgEl.hidden = true;
+
+    if (translatorState.pendingOpen) {
+      showTranslatorPanel();
+      const select = document.querySelector("#google_translate_element select");
+      if (select) {
+        requestAnimationFrame(() => select.focus());
+      }
+    }
+    translatorState.pendingOpen = false;
+
+    if (typeof translatorInitResolve === "function") translatorInitResolve();
+  } catch (err) {
+    translatorState.ready = false;
+    translatorState.scriptPromise = null;
+    translatorState.pendingOpen = false;
+    updateTranslatorMessage("Google Translate could not be loaded.");
+    if (typeof translatorInitReject === "function") translatorInitReject(err);
+    console.warn("⚠️ googleTranslateElementInit error", err);
+  } finally {
+    translatorInitResolve = null;
+    translatorInitReject = null;
+  }
+};
+
 
 
 // === Load JSON with cache-bypass & safe parse (FINAL FIX 2025-11-02) ===

--- a/style.css
+++ b/style.css
@@ -20,13 +20,59 @@ a { color: #0b63c5; text-decoration: none; }
 a:hover { text-decoration: underline; }
 
 
-header { background: var(--steel-blue); color: #fff; padding: .5rem .8rem; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid #fff1f; height: 80px; flex-direction: column; position: relative; z-index: 1000; flex-wrap: wrap; padding-top: .6rem; padding-bottom: .4rem; min-height: 72px; }
+header { background: var(--steel-blue); color: #fff; padding: .5rem .8rem; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid #fff1f; min-height: 72px; position: relative; z-index: 1000; flex-wrap: wrap; gap: .75rem; }
+
+#main-header {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+#main-header .header-branding {
+  display: flex;
+  align-items: center;
+  gap: .6rem;
+  flex: 1 1 auto;
+  min-width: 200px;
+}
+
+#logo-link {
+  display: inline-flex;
+  align-items: center;
+  gap: .6rem;
+  color: #fff;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex: 0 1 auto;
+}
 
 
 header h1 { margin: 0; font-size: 1rem; font-weight: 600; }
 
 
 nav { display: flex; gap: .6rem; align-items: center; flex-wrap: wrap; justify-content: center; }
+
+@media (max-width: 720px) {
+  #main-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .header-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .translator-launcher {
+    margin-left: auto;
+  }
+}
 
 
 nav a { color: var(--link-muted); font-weight: 500; }
@@ -2046,4 +2092,206 @@ body.glossary-page th.sort-asc::after {
 body.glossary-page th.sort-desc::after {
   content: " ↓";
   color: #007bff;
+}
+
+/* === Translator Controls === */
+.translator-launcher {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.translator-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 2px solid #fff;
+  background: #fff;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 6px #0003;
+  transition: transform .2s ease, box-shadow .2s ease;
+}
+
+.translator-button .translator-icon {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  display: block;
+}
+
+.translator-button:focus-visible {
+  outline: 3px solid #ffd166;
+  outline-offset: 2px;
+}
+
+.translator-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 10px #0004;
+}
+
+
+.translator-panel {
+  position: absolute;
+  right: 0;
+  top: calc(100% + .65rem);
+  width: min(260px, 80vw);
+  background: #fff;
+  color: #111;
+  border-radius: 12px;
+  box-shadow: 0 12px 30px #00000033;
+  border: 1px solid #d8dde6;
+  padding: .75rem;
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+  z-index: 2500;
+}
+
+.translator-panel[hidden] {
+  display: none;
+}
+
+.translator-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .5rem;
+  font-weight: 600;
+  font-size: .95rem;
+}
+
+.translator-close {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1.1rem;
+  cursor: pointer;
+  padding: 0 .25rem;
+  line-height: 1;
+}
+
+.translator-close:focus-visible {
+  outline: 2px solid var(--accent);
+  border-radius: 4px;
+}
+
+.translator-panel-body {
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+}
+
+.translator-panel-body select {
+  width: 100% !important;
+  padding: .4rem;
+  border-radius: 6px;
+  border: 1px solid #cbd5e1;
+  font-size: .95rem;
+  background: #fff;
+  color: #111;
+}
+
+.translator-loading-message {
+  font-size: .85rem;
+  color: #445;
+  margin: 0;
+}
+
+.translator-widget:empty {
+  display: none;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.translator-consent-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 25, 40, .65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 4000;
+}
+
+.translator-consent-overlay[hidden] {
+  display: none;
+}
+
+.translator-consent-dialog {
+  background: #fff;
+  color: #111;
+  max-width: 480px;
+  width: 100%;
+  padding: 1.5rem;
+  border-radius: 16px;
+  box-shadow: 0 18px 45px #0000002b;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.translator-consent-dialog:focus-visible {
+  outline: 3px solid #ffd166;
+}
+
+.translator-consent-dialog h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.translator-consent-dialog p {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.translator-consent-note {
+  font-size: .85rem;
+  color: #444f;
+}
+
+.translator-consent-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .5rem;
+  justify-content: flex-end;
+}
+
+.translator-consent-actions button {
+  border: none;
+  border-radius: 8px;
+  padding: .55rem 1.1rem;
+  font-size: .95rem;
+  cursor: pointer;
+}
+
+.translator-consent-accept {
+  background: var(--accent);
+  color: #fff;
+}
+
+.translator-consent-cancel {
+  background: #e2e8f0;
+  color: #111;
+}
+
+.translator-consent-actions button:focus-visible {
+  outline: 2px solid var(--accent-light);
+  outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
- replace the translator launcher flags with the shared translate icon asset
- update the translator consent dialog and messaging to English, including error notices
- refresh the privacy policy translation section with English-only wording

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69160cb85940832dba0a5eb72e6d0f96)