### PR TITLE
Improve spinner focus handling and accessibility affordances

### DIFF
--- a/about.html
+++ b/about.html
@@ -28,7 +28,7 @@
 </head>
 
 <body>
-	<button id="scroll-top-btn" title="Scroll to top">⬆️</button>
+  <button id="scroll-top-btn" title="Scroll to top" aria-label="Scroll to top">⬆️</button>
   <!-- 🌍 Intro -->
   <section class="page-intro">
     <h1>💡 About RealityCheck</h1>

--- a/analysis.html
+++ b/analysis.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-	<button id="scroll-top-btn" title="Scroll to top">⬆️</button>
+    <button id="scroll-top-btn" title="Scroll to top" aria-label="Scroll to top">⬆️</button>
   <section class="page-intro">
     <h1>🧠 Global KPI Analysis</h1>
     <p>

--- a/countries.html
+++ b/countries.html
@@ -23,7 +23,7 @@
   <a id="page-top"></a>
 
   <div id="overlay-spinner" class="hidden"></div>
-	<button id="scroll-top-btn" title="Scroll to top">⬆️</button>
+        <button id="scroll-top-btn" title="Scroll to top" aria-label="Scroll to top">⬆️</button>
 	 
   <section class="page-intro">
     <h1>🗺️ Countries Dashboard</h1>
@@ -94,12 +94,12 @@
 			<table id="country-table" aria-label="Country data table">
 				<thead>
 					<tr>
-						<th data-col="rank">Rank</th>
-						<th data-col="country">Country</th>
-						<th data-col="value">Value</th>
-						<th title="Change vs previous year">Δ vs Prev</th>
-						<th title="Change vs comparison year">Δ vs Year</th>
-						<th>Update</th>
+                                                <th scope="col" data-col="rank">Rank</th>
+                                                <th scope="col" data-col="country">Country</th>
+                                                <th scope="col" data-col="value">Value</th>
+                                                <th scope="col" title="Change vs previous year">Δ vs Prev</th>
+                                                <th scope="col" title="Change vs comparison year">Δ vs Year</th>
+                                                <th scope="col">Update</th>
 					</tr>
 				</thead>
 				<tbody></tbody>

--- a/data_glossary.html
+++ b/data_glossary.html
@@ -13,7 +13,7 @@
 
   <!-- 🔄 Lade-Spinner -->
   <div id="overlay-spinner" class="hidden"></div>
-  <button id="scroll-top-btn" title="Scroll to top">⬆️</button>
+  <button id="scroll-top-btn" title="Scroll to top" aria-label="Scroll to top">⬆️</button>
 
   <!-- 🌍 Intro -->
   <section class="page-intro">
@@ -29,13 +29,13 @@
     <table id="glossary-table">
       <thead>
         <tr>
-          <th class="sortable">KPI</th>
-          <th class="sortable">Source</th>
-          <th class="sortable">Data Year</th>
-          <th class="sortable">Source Date</th>
-          <th class="sortable">Last Fetch</th>
-          <th class="sortable">Countries</th>
-          <th class="sortable">Outliers</th>
+          <th scope="col" class="sortable">KPI</th>
+          <th scope="col" class="sortable">Source</th>
+          <th scope="col" class="sortable">Data Year</th>
+          <th scope="col" class="sortable">Source Date</th>
+          <th scope="col" class="sortable">Last Fetch</th>
+          <th scope="col" class="sortable">Countries</th>
+          <th scope="col" class="sortable">Outliers</th>
         </tr>
       </thead>
       <tbody id="glossary-body">

--- a/footer.html
+++ b/footer.html
@@ -10,6 +10,7 @@
 		<a href="impressum.html">⚖️ Impressum</a> |
     <a href="privacy.html">🔒 Privacy</a> |
     <a href="https://github.com/ckvfox/realitycheck" target="_blank" title="View on GitHub"
+       rel="noopener noreferrer"
        style="display:inline-flex;align-items:center;gap:4px;">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"
            width="14" height="14" fill="white" aria-hidden="true">

--- a/overall_ranking_countries.html
+++ b/overall_ranking_countries.html
@@ -12,7 +12,7 @@
 
   <!-- 🔄 Lade-Spinner -->
   <div id="overlay-spinner" class="hidden"></div>
-	<button id="scroll-top-btn" title="Scroll to top">⬆️</button>
+        <button id="scroll-top-btn" title="Scroll to top" aria-label="Scroll to top">⬆️</button>
 
 	<section class="page-intro">
 	  <h1>📊 Overall Country Ranking</h1>
@@ -59,10 +59,10 @@
     <table id="overall-table">
       <thead>
         <tr>
-          <th>Rank</th>
-          <th>Country</th>
-          <th>Score</th>
-          <th>KPIs used</th>
+          <th scope="col">Rank</th>
+          <th scope="col">Country</th>
+          <th scope="col">Score</th>
+          <th scope="col">KPIs used</th>
         </tr>
       </thead>
       <tbody>

--- a/scripts/core.js
+++ b/scripts/core.js
@@ -408,11 +408,15 @@ function showSpinner(show = true, msg = "Loading…") {
     sp.classList.remove("hidden");
     sp.style.opacity = "1";
 
-    // Spinner immer im sichtbaren Bereich halten (auch im iframe)
-    try {
-      window.scrollTo({ top: 0, behavior: "instant" });
-    } catch {
-      /* ignore */
+    // Nur beim ersten Einblenden nach dem Laden automatisch nach oben springen,
+    // um unerwartete Fokuswechsel bei wiederholter Nutzung zu vermeiden.
+    if (!sp.dataset.scrolled) {
+      try {
+        window.scrollTo({ top: 0, behavior: "instant" });
+      } catch {
+        /* ignore */
+      }
+      sp.dataset.scrolled = "1";
     }
   } else {
     sp.style.opacity = "0";

--- a/world.html
+++ b/world.html
@@ -13,7 +13,7 @@
 <body class="world-page">
   <!-- 🔄 Lade-Spinner -->
   <div id="overlay-spinner" class="hidden"></div>
-	<button id="scroll-top-btn" title="Scroll to top">⬆️</button>
+        <button id="scroll-top-btn" title="Scroll to top" aria-label="Scroll to top">⬆️</button>
 
   <!-- 🌍 Intro -->
   <section class="page-intro">


### PR DESCRIPTION
## Summary
- guard the shared loading spinner so it only auto-scrolls on first display, preventing repeated focus jumps
- add `aria-label` support to scroll-to-top buttons and mark table headers with `scope="col"` for better screen reader hints
- secure the external GitHub footer link with `rel="noopener noreferrer"`

## Testing
- not run (static changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691633f33484832d8b09c6b6faa15183)