### PR TITLE
Adjust mobile spacing for overall ranking legend

### DIFF
--- a/style.css
+++ b/style.css
@@ -265,6 +265,8 @@ body.overall-page #legend {
   display: grid;
   gap: 1.5rem;
   margin-top: 2.5rem;
+  padding-inline: clamp(16px, 5vw, 40px);
+  box-sizing: border-box;
 }
 
 @media (min-width: 880px) {


### PR DESCRIPTION
## Summary
- add responsive inline padding to the overall ranking legend so it stays within the viewport on mobile

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916cd338658832dad63f9f53fee0b4f)