### PR TITLE
Make translator toggle float at top-right of viewport

### DIFF
--- a/style.css
+++ b/style.css
@@ -50,6 +50,14 @@ header { background: var(--steel-blue); color: #fff; padding: .5rem .8rem; displ
   align-items: center;
   gap: 1rem;
   flex: 0 1 auto;
+  box-sizing: border-box;
+  padding-right: 3.5rem;
+}
+
+@supports (padding-right: calc(3.5rem + env(safe-area-inset-right))) {
+  .header-actions {
+    padding-right: calc(3.5rem + env(safe-area-inset-right));
+  }
 }
 
 
@@ -67,10 +75,25 @@ nav { display: flex; gap: .6rem; align-items: center; flex-wrap: wrap; justify-c
   .header-actions {
     width: 100%;
     justify-content: space-between;
+    padding-right: 2.75rem;
+  }
+
+  @supports (padding-right: calc(2.75rem + env(safe-area-inset-right))) {
+    .header-actions {
+      padding-right: calc(2.75rem + env(safe-area-inset-right));
+    }
   }
 
   .translator-launcher {
-    margin-left: auto;
+    top: .75rem;
+    right: .75rem;
+  }
+
+  @supports (top: calc(.75rem + env(safe-area-inset-top))) {
+    .translator-launcher {
+      top: calc(.75rem + env(safe-area-inset-top));
+      right: calc(.75rem + env(safe-area-inset-right));
+    }
   }
 }
 
@@ -2098,10 +2121,20 @@ body.glossary-page th.sort-desc::after {
 
 /* === Translator Controls === */
 .translator-launcher {
-  position: relative;
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
   display: flex;
   align-items: center;
   justify-content: center;
+  z-index: 3000;
+}
+
+@supports (top: calc(1rem + env(safe-area-inset-top))) {
+  .translator-launcher {
+    top: calc(1rem + env(safe-area-inset-top));
+    right: calc(1rem + env(safe-area-inset-right));
+  }
 }
 
 .translator-button {


### PR DESCRIPTION
## Summary
- reposition the Google Translate toggle as a floating control pinned to the viewport top-right
- adjust header spacing to keep navigation clear while respecting safe-area insets

## Testing
- No automated tests were run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916cf96bed4832dadecce561f1bf69b)