### PR TITLE
Refactor shared script utilities and CLI flow

### DIFF
--- a/scripts/analysis.py
+++ b/scripts/analysis.py
@@ -15,20 +15,17 @@ import os, sys, json, time, math, traceback
 from datetime import datetime, timezone, date
 from pathlib import Path
 from statistics import mean, pstdev
-from dotenv import load_dotenv
-from openai import OpenAI
-from httpx import Client as HttpxClient
 
 try:
     from tqdm import tqdm
 except Exception:
     def tqdm(x, **k): return x
 
-from env_utils import get_openai_key
+from env_utils import get_openai_client
+from script_utils import ensure_utf8_stdout, safe_write_json, safe_write_text, setup_logger
 
 # === UTF-8 ===
-if sys.stdout.encoding is None or sys.stdout.encoding.lower() != "utf-8":
-    sys.stdout.reconfigure(encoding="utf-8")
+ensure_utf8_stdout()
 
 # === Pfade ===
 SCRIPT_DIR = Path(__file__).parent.resolve()
@@ -42,31 +39,12 @@ OUT_KPI = DATA_DIR / "kpi_analysis.json"
 OUT_OUTLIERS = DATA_DIR / "analysis_outliers.json"
 LOG_FILE = DATA_DIR / "fetch_log.txt"
 
-# === OpenAI ===
-load_dotenv()
-client = OpenAI(api_key=get_openai_key(), http_client=HttpxClient())
-
 # === Logging ===
-def log(msg:str):
-    ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
-    line = f"[{ts}] {msg}"
-    print(line)
-    try:
-        with LOG_FILE.open("a", encoding="utf-8") as f: f.write(line+"\n")
-    except Exception: pass
+logger = setup_logger("analysis", LOG_FILE)
 
-# === Safe Writes ===
-def safe_write_text(p:Path, c:str):
-    p.parent.mkdir(parents=True, exist_ok=True)
-    tmp=p.with_suffix(p.suffix+".tmp")
-    tmp.write_text(c or "⚠️ Empty content", encoding="utf-8")
-    os.replace(tmp,p)
 
-def safe_write_json(p:Path, d):
-    p.parent.mkdir(parents=True, exist_ok=True)
-    tmp=p.with_suffix(p.suffix+".tmp")
-    tmp.write_text(json.dumps(d, ensure_ascii=False, indent=2), encoding="utf-8")
-    os.replace(tmp,p)
+def log(msg: str) -> None:
+    logger.info(msg)
 
 # === Loader ===
 def load_meta():
@@ -92,6 +70,7 @@ def gpt_call(prompt: str, max_tokens: int = 700) -> str:
     """Robuster GPT-Call – mit Fallback und optionalem Silent Mode."""
     text = ""
     last_err = None
+    client = get_openai_client()
 
     for model in ["gpt-4o", "gpt-4-turbo"]:
         if VERBOSE:
@@ -196,7 +175,7 @@ Be factual but interpretative, analytical but not technical.
 
 
 # === KPI Analysen ===
-def generate_kpi_analyses(client:OpenAI,data_dir:Path,updated_only=None):
+def generate_kpi_analyses(data_dir: Path, updated_only=None):
     meta=load_meta()
     if updated_only and "__force_all__" not in updated_only:
         allow={u.replace(".json","") for u in updated_only}
@@ -296,7 +275,11 @@ if __name__=="__main__":
     if not updated: updated=["__force_all__"]
     try: run_global_analysis(updated)
     except Exception as e: log(f"❌ Global analysis failed: {e}\n{traceback.format_exc()}")
-    try: generate_kpi_analyses(client,DATA_DIR,updated_only=None if "__force_all__" in updated else updated)
+    try:
+        generate_kpi_analyses(
+            DATA_DIR,
+            updated_only=None if "__force_all__" in updated else updated,
+        )
     except Exception as e: log(f"⚠️ KPI summary failed: {e}")
     try: compute_outliers()
     except Exception as e: log(f"⚠️ Outlier computation failed: {e}")

--- a/scripts/check_source_csv_updates.py
+++ b/scripts/check_source_csv_updates.py
@@ -6,20 +6,18 @@
 Fragt GPT (via OpenAI 1.54.x) ab, ob für CSV-basierte KPIs neuere Versionen existieren.
 """
 
-import os
 import sys
 import json
 import time
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from dotenv import load_dotenv
-from openai import OpenAI
-from env_utils import get_openai_key
+
+from env_utils import get_openai_client
+from script_utils import ensure_utf8_stdout, setup_logger
 
 # === UTF-8 ===
-if sys.stdout.encoding is None or sys.stdout.encoding.lower() != "utf-8":
-    sys.stdout.reconfigure(encoding="utf-8")
+ensure_utf8_stdout()
 
 # === Pfade & Logging ===
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -28,18 +26,7 @@ META_PATH = DATA_DIR / "meta" / "available_kpis.json"
 FETCH_STATUS_PATH = DATA_DIR / "fetch_status.json"
 LOGFILE_PATH = DATA_DIR / "fetch_log.txt"
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="[{asctime} UTC] {message}",
-    datefmt="%Y-%m-%dT%H:%M:%S",
-    style="{",
-    handlers=[
-        logging.StreamHandler(sys.stdout),
-        logging.FileHandler(LOGFILE_PATH, encoding="utf-8", mode="a"),
-    ],
-)
-
-log = logging.getLogger("csv_update")
+logger = setup_logger("csv_update", LOGFILE_PATH)
 
 # === Silence internal OpenAI/httpx request logs ===
 import logging
@@ -48,37 +35,6 @@ logging.getLogger("openai._base_client").setLevel(logging.WARNING)
 logging.getLogger("openai._client").setLevel(logging.WARNING)
 
 # === OpenAI ===
-from httpx import Client as HttpxClient  # <- wichtig: import ergänzen
-load_dotenv()
-OPENAI_API_KEY = get_openai_key()
-
-# eigener httpx-Client verhindert den "proxies"-Fehler unter Python 3.13
-client = OpenAI(api_key=OPENAI_API_KEY, http_client=HttpxClient())
-
-# ======================================================================
-# 💾 Safe Write Helpers
-# ======================================================================
-def safe_write_text(path: Path, content: str):
-    """Garantiert UTF-8-Schreiben mit automatischer Ordnererstellung."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        with path.open("w", encoding="utf-8") as f:
-            f.write(content or "")
-        log.info(f"💾 Wrote text file: {path.name}")
-    except Exception as e:
-        log.error(f"❌ Failed to write text file {path}: {e}")
-
-def safe_write_json(path: Path, data):
-    """Garantiert sicheres Schreiben von JSON-Dateien."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        with path.open("w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-        log.info(f"💾 JSON saved: {path.name} ({len(data)} keys)")
-    except Exception as e:
-        log.error(f"❌ Failed to write JSON {path}: {e}")
-
-
 # === GPT Lookup ===
 def gpt_lookup_latest_year(title: str, last_year: int) -> int | None:
     current_year = datetime.now(timezone.utc).year
@@ -91,6 +47,7 @@ Last known year: {last_year}
 """.strip()
 
     try:
+        client = get_openai_client()
         rsp = client.chat.completions.create(
             model="gpt-4-turbo",
             messages=[
@@ -100,7 +57,7 @@ Last known year: {last_year}
             max_completion_tokens=50
         )
         text = (rsp.choices[0].message.content or "").strip()
-        log.info(f"🤖 GPT response for '{title}': {text}")
+        logger.info(f"🤖 GPT response for '{title}': {text}")
 
         years = [
             int(s) for s in text.replace(",", " ").split()
@@ -113,7 +70,7 @@ Last known year: {last_year}
         return None
 
     except Exception as e:
-        log.warning(f"⚠️ GPT error for '{title}': {e}")
+        logger.warning(f"⚠️ GPT error for '{title}': {e}")
         return None
 
 
@@ -123,32 +80,32 @@ def main():
         available = json.loads(META_PATH.read_text(encoding="utf-8"))
         fetch_status = json.loads(FETCH_STATUS_PATH.read_text(encoding="utf-8"))
     except Exception as e:
-        log.error(f"❌ Load error: {e}")
+        logger.error(f"❌ Load error: {e}")
         sys.exit(1)
 
     kpi_list = available if isinstance(available, list) else list(available.values())
     csv_kpis = [m for m in kpi_list if str(m.get("source_type", "")).lower() == "csv"]
-    log.info(f"➡️ Starting CSV update check for {len(csv_kpis)} KPIs…")
+    logger.info(f"➡️ Starting CSV update check for {len(csv_kpis)} KPIs…")
 
     for meta in csv_kpis:
         title = meta.get("title", "Unknown")
         fname = meta.get("filename", "unknown")
         last_year = int((fetch_status.get("kpis", {}).get(fname, {}).get("data_year") or 0))
 
-        log.info(f"🔍 Checking '{title}' (last known year: {last_year or 'None'})")
+        logger.info(f"🔍 Checking '{title}' (last known year: {last_year or 'None'})")
         latest = gpt_lookup_latest_year(title, last_year)
         time.sleep(3)
 
         if latest is None:
-            log.info(f"❓ No newer version for '{title}' found.")
+            logger.info(f"❓ No newer version for '{title}' found.")
         elif not last_year:
-            log.warning(f"🆕 Possibly updated: '{title}' → {latest}.")
+            logger.warning(f"🆕 Possibly updated: '{title}' → {latest}.")
         elif latest > last_year:
-            log.warning(f"🆕 Possibly updated: '{title}' → {latest} > {last_year}.")
+            logger.warning(f"🆕 Possibly updated: '{title}' → {latest} > {last_year}.")
         else:
-            log.info(f"⏸️ Up-to-date ({latest} = {last_year})")
+            logger.info(f"⏸️ Up-to-date ({latest} = {last_year})")
 
-    log.info("✅ Smart CSV update check completed.")
+    logger.info("✅ Smart CSV update check completed.")
 
 
 if __name__ == "__main__":

--- a/scripts/env_utils.py
+++ b/scripts/env_utils.py
@@ -1,9 +1,41 @@
+"""Environment helpers for RealityCheck scripts."""
+from __future__ import annotations
+
 import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
 from dotenv import load_dotenv
 
-def get_openai_key():
-    load_dotenv(os.path.join(os.path.dirname(__file__), "..", ".env"))
+
+_DOTENV_LOADED = False
+
+
+def _load_dotenv(env_path: Optional[Path] = None) -> None:
+    global _DOTENV_LOADED
+    if _DOTENV_LOADED:
+        return
+
+    if env_path is None:
+        env_path = Path(__file__).resolve().parent.parent / ".env"
+
+    load_dotenv(env_path)
+    _DOTENV_LOADED = True
+
+
+@lru_cache(maxsize=1)
+def get_openai_key() -> str:
+    _load_dotenv()
     key = os.getenv("OPENAI_API_KEY")
     if not key:
         raise ValueError("❌ OPENAI_API_KEY missing – define in .env or GitHub Secrets.")
     return key
+
+
+@lru_cache(maxsize=1)
+def get_openai_client():
+    from httpx import Client as HttpxClient
+    from openai import OpenAI
+
+    return OpenAI(api_key=get_openai_key(), http_client=HttpxClient())

--- a/scripts/fetch_data.py
+++ b/scripts/fetch_data.py
@@ -26,9 +26,6 @@ import subprocess
 from typing import Any, Dict, List, Optional
 from pathlib import Path
 from datetime import datetime, timezone
-from dotenv import load_dotenv
-from openai import OpenAI
-from httpx import Client as HttpxClient  # verhindert "proxies"-Fehler unter Python 3.13
 from env_utils import get_openai_key  # ✅ wichtig: hier fehlte der Import
 
 
@@ -37,15 +34,10 @@ from env_utils import get_openai_key  # ✅ wichtig: hier fehlte der Import
 if sys.stdout.encoding is None or sys.stdout.encoding.lower() != "utf-8":
     sys.stdout.reconfigure(encoding="utf-8")
 
-OPENAI_API_KEY = get_openai_key()
-client = OpenAI(api_key=OPENAI_API_KEY, http_client=HttpxClient())
-
 
 # ======================================================================
 # 🔧 Pfade (pathlib-Version – robust gegen OS-Unterschiede)
 # ======================================================================
-from pathlib import Path
-
 SCRIPT_DIR = Path(__file__).parent.resolve()
 ROOT_DIR   = SCRIPT_DIR.parent.resolve()
 DATA_DIR   = ROOT_DIR / "data"
@@ -63,13 +55,31 @@ STATUS_FILE          = DATA_DIR / "fetch_status.json"
 
 
 # === Argumente ===
-parser = argparse.ArgumentParser(description="RealityCheck Fetcher")
-parser.add_argument("-f", "--force", action="store_true", help="Force full refetch (clear /data except /meta)")
-args = parser.parse_args()
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="RealityCheck Fetcher")
+    parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Force full refetch (clear /data except /meta)",
+    )
+    parser.add_argument(
+        "-n",
+        "--no-analysis",
+        action="store_true",
+        help="Skip AI-based analysis and ranking follow-up tasks",
+    )
+    return parser
 
-# === Force Mode: Clean Data ===
-if args.force:
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    return build_parser().parse_args(argv)
+
+
+def handle_force_cleanup() -> None:
     print("[INFO] Force mode enabled – clearing data except /meta …")
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
 
     for item in DATA_DIR.iterdir():
         if item.name == "meta":
@@ -1051,9 +1061,20 @@ def merge_fetch_state(updated_kpis: set):
 # ======================================================================
 # 🚀 Main
 # ======================================================================
-def main():
+def main(args: argparse.Namespace) -> None:
+    if args.force:
+        handle_force_cleanup()
+
     ensure_dirs()
-    log(f"[INFO] Using OPENAI_API_KEY: {'found' if os.getenv('OPENAI_API_KEY') else 'missing'}")
+
+    try:
+        get_openai_key()
+        key_status = "found"
+    except ValueError as exc:
+        key_status = "missing"
+        log(f"[WARN] {exc}")
+
+    log(f"[INFO] Using OPENAI_API_KEY: {key_status}")
     log("=== Fetch started ===")
 
     # --- Bestehenden Status laden ---
@@ -1258,18 +1279,15 @@ def main():
 
 
 # ======================================================================
-# ⚙️ Optionaler Parameter: --no-analysis
-# ======================================================================
-NO_ANALYSIS = ("--no-analysis" in sys.argv or "-n" in sys.argv)
-if NO_ANALYSIS:
-    print("⏸️ Smart analyses and GPT-based tasks are disabled (local test mode).")
-
-
-# ======================================================================
 # ▶ Start
 # ======================================================================
 if __name__ == "__main__":
-    main()
+    cli_args = parse_args()
+
+    if cli_args.no_analysis:
+        print("⏸️ Smart analyses and GPT-based tasks are disabled (local test mode).")
+
+    main(cli_args)
 
     try:
         print("➡️ Running fetch_overall_ranking.py …")
@@ -1287,7 +1305,6 @@ if __name__ == "__main__":
 
     # === Fetch-State zusammenführen ===
     try:
-        from pathlib import Path
         state_path = Path(DATA_DIR) / "fetch_state.json"
         updated_kpis = set()
         if state_path.exists():
@@ -1299,9 +1316,9 @@ if __name__ == "__main__":
         print(f"⚠️ State merge failed: {e}")
 
     # === Nur Analysen ausführen, wenn neue Daten da sind ===
-    if not NO_ANALYSIS:
+    if not cli_args.no_analysis:
         try:
-            if args.force or len(updated_kpis) > 0:
+            if cli_args.force or len(updated_kpis) > 0:
                 print(f"➡️ Starting global KPI analysis ({len(updated_kpis)} updates or forced run) …")
                 subprocess.run(["python", os.path.join(SCRIPT_DIR, "analysis.py")], check=True)
             else:

--- a/scripts/fetch_overall_ranking.py
+++ b/scripts/fetch_overall_ranking.py
@@ -11,8 +11,9 @@
 
 import json
 import subprocess
-from datetime import datetime, timezone
 from pathlib import Path
+
+from script_utils import ensure_utf8_stdout, safe_write_json, setup_logger
 
 # ======================================================================
 # 🔧 Pfade (pathlib-Version – robust gegen OS-Unterschiede)
@@ -30,13 +31,13 @@ OUTPUT_FILE          = DATA_DIR / "overall_ranking.json"  # ✅ hinzugefügt
 # ======================================================================
 # 🧰 Hilfsfunktionen
 # ======================================================================
-def log(msg: str):
-    """Schreibt Zeitstempel + Nachricht in Konsole & Logdatei (UTC)."""
-    line = f"[{datetime.now(timezone.utc).isoformat(timespec='seconds')} UTC] {msg}"
-    print(line)
-    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with LOG_FILE.open("a", encoding="utf-8") as f:
-        f.write(line + "\n")
+ensure_utf8_stdout()
+logger = setup_logger("overall_ranking", LOG_FILE)
+
+
+def log(message: str) -> None:
+    logger.info(message)
+
 
 def load_json(path: Path):
     with path.open("r", encoding="utf-8") as f:
@@ -54,19 +55,6 @@ def get_latest_values(entries):
         if country not in latest or year > latest[country]["year"]:
             latest[country] = {"year": year, "value": value}
     return latest
-# ======================================================================
-# 💾 Safe Write Helper
-# ======================================================================
-def safe_write_json(path: Path, data):
-    """Garantiert sicheres Schreiben einer JSON-Datei mit UTF-8 und Verzeichnis-Erstellung."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        with path.open("w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-        log(f"💾 JSON saved successfully → {path.relative_to(ROOT_DIR)} ({len(data)} records)")
-    except Exception as e:
-        log(f"❌ Failed to write JSON file {path}: {e}")
-
 # ======================================================================
 # 🚀 Main
 # ======================================================================
@@ -151,7 +139,16 @@ def main():
     ]
 
     OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
-    safe_write_json(OUTPUT_FILE, result)
+    try:
+        safe_write_json(
+            OUTPUT_FILE,
+            result,
+            logger=logger,
+            note=f"💾 JSON saved successfully → {OUTPUT_FILE.relative_to(ROOT_DIR)} ({len(result)} records)",
+        )
+    except Exception as exc:
+        log(f"❌ Failed to write JSON file {OUTPUT_FILE}: {exc}")
+        return
 
 
     log(f"✅ overall_ranking.json written to {OUTPUT_FILE}")

--- a/scripts/generate_fun_safe_rankings.py
+++ b/scripts/generate_fun_safe_rankings.py
@@ -10,64 +10,40 @@ Erzeugt:
 Verwendet dieselbe GPT-Logik wie analysis.py (OpenAI 1.54.x)
 """
 
-import os
 import sys
 import json
-import time
 from datetime import datetime, timezone
-from dotenv import load_dotenv
-from openai import OpenAI
 from pathlib import Path
-from env_utils import get_openai_key
-from httpx import Client as HttpxClient  # 🔧 Fix für Python 3.13 Proxy-Bug
+
+from env_utils import get_openai_client
+from script_utils import ensure_utf8_stdout, safe_write_json, setup_logger
 
 # === UTF-8 Fix ===
-if sys.stdout.encoding is None or sys.stdout.encoding.lower() != "utf-8":
-    sys.stdout.reconfigure(encoding="utf-8")
-
-# === OpenAI Setup ===
-load_dotenv()
-OPENAI_API_KEY = get_openai_key()
-client = OpenAI(api_key=OPENAI_API_KEY, http_client=HttpxClient())  # eigener Client für Python 3.13
+ensure_utf8_stdout()
 
 # === Pfade ===
 ROOT_DIR = Path(__file__).resolve().parent.parent
 DATA_DIR = ROOT_DIR / "data"
 LOG_FILE = DATA_DIR / "fetch_log.txt"
 
-# === Safe Write Helpers ===
-def safe_write_text(path: Path, content: str):
-    path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        with path.open("w", encoding="utf-8") as f:
-            f.write(content or "")
-    except Exception as e:
-        print(f"❌ Failed to write text file {path}: {e}")
-
-def safe_write_json(path: Path, data):
-    path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        with path.open("w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-        print(f"💾 JSON saved: {path.relative_to(Path(__file__).resolve().parent.parent)} ({len(data)} entries)")
-    except Exception as e:
-        print(f"❌ Failed to write JSON file {path}: {e}")
-
 # === Logging ===
-def log(msg: str):
-    ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
-    line = f"[{ts}] {msg}"
-    print(line)
-    with LOG_FILE.open("a", encoding="utf-8") as f:
-        f.write(line + "\n")
+logger = setup_logger("fun_safe_rankings", LOG_FILE)
+
+
+def log(msg: str) -> None:
+    logger.info(msg)
 
 def save_json(data, path: Path):
     if not data:
         log(f"⚠️ No data to save for {path.name}")
         return
     try:
-        safe_write_json(path, data)
-        log(f"💾 Saved {path.relative_to(ROOT_DIR)} ({len(data)} entries)")
+        safe_write_json(
+            path,
+            data,
+            logger=logger,
+            note=f"💾 Saved {path.relative_to(ROOT_DIR)} ({len(data)} entries)",
+        )
     except Exception as e:
         log(f"❌ Failed to save {path.name}: {e}")
 
@@ -121,6 +97,7 @@ Example:
 # === Core ===
 def generate_ranking(mode: str, prompt: str, path: Path):
     log(f"➡️ Generating {mode} via GPT-4-Turbo …")
+    client = get_openai_client()
     try:
         response = client.chat.completions.create(
             model="gpt-4-turbo",

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -1,0 +1,75 @@
+"""Shared helpers for RealityCheck command-line scripts."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+
+def ensure_utf8_stdout() -> None:
+    """Force UTF-8 encoding for stdout if possible."""
+    if sys.stdout.encoding is None or sys.stdout.encoding.lower() != "utf-8":
+        sys.stdout.reconfigure(encoding="utf-8")
+
+
+def utc_now_iso(timespec: str = "seconds") -> str:
+    """Return the current UTC timestamp in ISO 8601 format."""
+    return datetime.now(timezone.utc).isoformat(timespec=timespec).replace("+00:00", "Z")
+
+
+def setup_logger(name: str, log_file: Path, *, level: int = logging.INFO) -> logging.Logger:
+    """Return a logger that writes to stdout and the provided file."""
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    formatter = logging.Formatter("[%(asctime)s UTC] %(message)s", datefmt="%Y-%m-%dT%H:%M:%S")
+
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(formatter)
+
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+
+    logger.setLevel(level)
+    logger.addHandler(stream_handler)
+    logger.addHandler(file_handler)
+    logger.propagate = False
+    return logger
+
+
+def _write_atomic(path: Path, content: str) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(content, encoding="utf-8")
+    os.replace(tmp_path, path)
+
+
+def safe_write_text(path: Path, content: str, *, logger: Optional[logging.Logger] = None, note: str = "") -> None:
+    """Safely write UTF-8 text to ``path`` using an atomic replace."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _write_atomic(path, content or "")
+    if logger:
+        logger.info(note or f"Text written → {path}")
+
+
+def safe_write_json(path: Path, data: Any, *, logger: Optional[logging.Logger] = None, note: str = "") -> None:
+    """Safely write JSON data to ``path``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    serialized = json.dumps(data, ensure_ascii=False, indent=2)
+    _write_atomic(path, serialized)
+    if logger:
+        logger.info(note or f"JSON written → {path}")
+
+
+def read_json(path: Path, default: Any = None) -> Any:
+    """Read JSON content returning ``default`` on failure."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return default


### PR DESCRIPTION
## Summary
- add a shared `script_utils` module for logging, safe-write helpers, and UTF-8 stdout handling
- cache environment loading and expose a reusable OpenAI client in `env_utils`
- update fetch and analysis scripts to use the shared utilities, support CLI args, and lazily create OpenAI clients

## Testing
- python -m compileall scripts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916cf5b345c832da1561a1a3a7a894b)