### PR TITLE
Adjust spacing between mode button icon and label

### DIFF
--- a/style.css
+++ b/style.css
@@ -2022,7 +2022,7 @@ Fixes: header/menu overflow, footer overflow, disappearing icons
 #mode-switch .mode-button span:not(.emoji) {
   display: inline-block !important;
   font-size: 0.85rem;
-  margin-left: 0.3rem;
+  margin-left: 0.2rem;
 }
 
 /* Mobile Optimierung – kleinere Buttons */


### PR DESCRIPTION
## Summary
- reduce the horizontal gap between the emoji icon and label text on desktop mode buttons for a tidier appearance

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691719fe02b0832da61ea00904e99165)