### PR TITLE
Refine shared UI styling and reuse data helpers

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <title>RealityCheck Chatbot (Demo)</title>
 <link rel="stylesheet" href="style_chat.css">
+<script src="scripts/core.js" defer></script>
 <script src="chat_demo.js" defer></script>
 </head>
 <body>

--- a/data_glossary.html
+++ b/data_glossary.html
@@ -39,7 +39,7 @@
         </tr>
       </thead>
       <tbody id="glossary-body">
-        <tr><td colspan="7" style="text-align:center;">Loading data…</td></tr>
+        <tr><td colspan="7" class="table-placeholder">Loading data…</td></tr>
       </tbody>
     </table>
 
@@ -107,6 +107,15 @@
         return latest.size;
       }
 
+      const isSafeUrl = url => {
+        try {
+          const parsed = new URL(url, window.location.href);
+          return ["http:", "https:"].includes(parsed.protocol);
+        } catch {
+          return false;
+        }
+      };
+
       for (const [id, info] of Object.entries(kpis)) {
         const tr = document.createElement("tr");
         const out = outliers[id] || {};
@@ -132,18 +141,68 @@
         const pct = ((n / totalCountries) * 100).toFixed(0);
         const title = titleMap[id] || id;
 
-        // ✅ Farblich markierte Datumsspalten + einheitliches Format
-        tr.innerHTML = `
-          <td>${title}</td>
-          <td>${info.source ? `<a href="${info.source}" target="_blank">${info.source}</a>` : "?"}</td>
-          <td class="${clsYear}">${info.data_year || "Unknown"}</td>
-          <td class="${clsSrc}">${fmtShort(info.source_date)}</td>
-          <td class="${clsSrc}">${fmtShort(info.last_fetch)}</td>
-          <td title="Coverage: ${pct}%">${n || "–"}</td>
-          <td>
-            ${flaggedCount ? `🔺 ${flaggedCount}` : "–"}
-            <span class="outlier-info"><strong>min:</strong> ${minInfo}<br><strong>max:</strong> ${maxInfo}</span>
-          </td>`;
+        const cellTitle = document.createElement("td");
+        cellTitle.textContent = title;
+        tr.appendChild(cellTitle);
+
+        const cellSource = document.createElement("td");
+        if (info.source && isSafeUrl(info.source)) {
+          const link = document.createElement("a");
+          link.href = info.source;
+          link.target = "_blank";
+          link.rel = "noopener";
+          link.textContent = info.source;
+          cellSource.appendChild(link);
+        } else {
+          cellSource.textContent = info.source || "?";
+        }
+        tr.appendChild(cellSource);
+
+        const cellDataYear = document.createElement("td");
+        cellDataYear.className = clsYear;
+        cellDataYear.textContent = info.data_year || "Unknown";
+        tr.appendChild(cellDataYear);
+
+        const cellSourceDate = document.createElement("td");
+        cellSourceDate.className = clsSrc;
+        cellSourceDate.textContent = fmtShort(info.source_date);
+        tr.appendChild(cellSourceDate);
+
+        const cellLastFetch = document.createElement("td");
+        cellLastFetch.className = clsSrc;
+        cellLastFetch.textContent = fmtShort(info.last_fetch);
+        tr.appendChild(cellLastFetch);
+
+        const cellCoverage = document.createElement("td");
+        cellCoverage.title = `Coverage: ${pct}%`;
+        cellCoverage.textContent = n || "–";
+        tr.appendChild(cellCoverage);
+
+        const cellOutliers = document.createElement("td");
+        if (flaggedCount) {
+          const badge = document.createElement("span");
+          badge.textContent = `🔺 ${flaggedCount}`;
+          badge.className = clsOut;
+          cellOutliers.appendChild(badge);
+        } else {
+          cellOutliers.textContent = "–";
+        }
+
+        const detail = document.createElement("span");
+        detail.className = "outlier-info";
+        const minStrong = document.createElement("strong");
+        minStrong.textContent = "min:";
+        const maxStrong = document.createElement("strong");
+        maxStrong.textContent = "max:";
+        detail.appendChild(minStrong);
+        detail.appendChild(document.createTextNode(` ${minInfo}`));
+        detail.appendChild(document.createElement("br"));
+        detail.appendChild(maxStrong);
+        detail.appendChild(document.createTextNode(` ${maxInfo}`));
+        cellOutliers.appendChild(detail);
+
+        tr.appendChild(cellOutliers);
+
         tbody.appendChild(tr);
       }
 
@@ -151,8 +210,15 @@
 
     } catch (err) {
       console.error("Glossary load failed:", err);
-      document.getElementById("glossary-body").innerHTML =
-        `<tr><td colspan="7" style="text-align:center;color:red;">Error loading data</td></tr>`;
+      const body = document.getElementById("glossary-body");
+      body.innerHTML = "";
+      const row = document.createElement("tr");
+      const cell = document.createElement("td");
+      cell.colSpan = 7;
+      cell.className = "table-status table-status--error";
+      cell.textContent = "Error loading data";
+      row.appendChild(cell);
+      body.appendChild(row);
     }
   }
 

--- a/overall_ranking_countries.html
+++ b/overall_ranking_countries.html
@@ -66,11 +66,11 @@
         </tr>
       </thead>
       <tbody>
-        <tr><td colspan="4" style="text-align:center;">Loading results...</td></tr>
+        <tr><td colspan="4" class="table-placeholder">Loading results...</td></tr>
       </tbody>
     </table>
   </div>
-  <p id="last-updated" style="margin-top:1em; font-size:0.9em; color:#555; text-align:center;"></p>
+  <p id="last-updated" class="table-status"></p>
 </section>
 
   <!-- JS -->

--- a/scripts/chat_demo.js
+++ b/scripts/chat_demo.js
@@ -3,6 +3,28 @@ document.addEventListener("DOMContentLoaded", () => {
   const send = document.getElementById("send");
   const messages = document.getElementById("messages");
 
+  const loadJSONSafe = async (path, fallback = {}) => {
+    try {
+      if (typeof window.loadJSON === "function") {
+        const result = await window.loadJSON(path);
+        if (
+          result == null ||
+          (Array.isArray(result) && !result.length && fallback !== undefined)
+        ) {
+          return fallback;
+        }
+        return result;
+      }
+
+      const response = await fetch(path);
+      if (!response.ok) throw new Error(`Failed to fetch ${path}`);
+      return await response.json();
+    } catch (error) {
+      console.warn("chat_demo: loadJSONSafe fallback", error);
+      return fallback;
+    }
+  };
+
   send.addEventListener("click", handleMessage);
   input.addEventListener("keypress", e => { if (e.key === "Enter") handleMessage(); });
 
@@ -26,8 +48,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const q = question.toLowerCase();
 
     // === Korrekte Pfade gemäß deiner Struktur ===
-    const countries = await loadJSON("countries.json").catch(() => ({}));
-    const available = await loadJSON("available_kpi.json").catch(() => ({}));
+    const countries = await loadJSONSafe("countries.json", {});
+    const available = await loadJSONSafe("available_kpi.json", {});
 
     // === Kontext laden ===
     const contextCountry = localStorage.getItem("currentCountry");
@@ -40,7 +62,7 @@ document.addEventListener("DOMContentLoaded", () => {
     // === Falls allgemeine Frage mit Kontext ===
     if (q.includes("wie steht") && contextCountry && contextKPI) {
       try {
-        const data = await loadJSON(`data/${contextKPI}.json`);
+        const data = await loadJSONSafe(`data/${contextKPI}.json`, []);
         const entry = findCountryData(data, contextCountry);
         if (entry) {
           return `${contextCountry} hat beim KPI '${contextKPI}' aktuell einen Wert von ${entry.value} (${entry.year}).`;
@@ -54,7 +76,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (country && kpi) {
       try {
-        const data = await loadJSON(`data/${kpi}.json`);
+        const data = await loadJSONSafe(`data/${kpi}.json`, []);
         const entry = findCountryData(data, country);
         if (entry) return `${country} hat beim KPI '${kpi}' aktuell einen Wert von ${entry.value} (${entry.year}).`;
         else return `Für ${country} liegen keine Daten zu '${kpi}' vor.`;
@@ -90,13 +112,6 @@ document.addEventListener("DOMContentLoaded", () => {
                    .sort((a,b)=>b.year - a.year)[0];
     return entry || null;
   }
-
-  async function loadJSON(path) {
-    const res = await fetch(path);
-    if (!res.ok) throw new Error(`Fehler beim Laden von ${path}`);
-    return res.json();
-  }
-
   function greetWithContext() {
     const c = localStorage.getItem("currentCountry");
     const k = localStorage.getItem("currentKPI");

--- a/scripts/fetch_consolidated.py
+++ b/scripts/fetch_consolidated.py
@@ -12,6 +12,8 @@ import json, gzip
 from datetime import datetime, timezone
 from pathlib import Path
 
+from script_utils import read_json, safe_write_json
+
 # ======================================================================
 # 🔧 Pfade (robust gegen OS-Unterschiede)
 # ======================================================================
@@ -26,13 +28,6 @@ MAX_SIZE_MB = 8.0  # Zielgröße pro Teil (InfinityFree Limit ≈5 MB)
 # ======================================================================
 # 🧰 Hilfsfunktionen
 # ======================================================================
-def load_json(path: Path):
-    try:
-        with path.open(encoding="utf-8") as f:
-            return json.load(f)
-    except Exception as e:
-        print(f"⚠️ Could not load {path}: {e}")
-        return {}
 
 def get_file_size_mb(path: Path) -> float:
     return path.stat().st_size / (1024 * 1024)
@@ -44,25 +39,12 @@ def gzip_json(data, path: Path):
         json.dump(data, f, separators=(",", ":"))
 
 # ======================================================================
-# 💾 Safe Write Helpers
-# ======================================================================
-def safe_write_json(path: Path, data):
-    """Garantiert sicheres Schreiben einer JSON-Datei mit UTF-8 und Verzeichnis-Erstellung."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        with path.open("w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-        print(f"💾 JSON saved successfully → {path.relative_to(ROOT_DIR)} ({len(data)} keys)")
-    except Exception as e:
-        print(f"❌ Failed to write {path}: {e}")
-
-# ======================================================================
 # 🚀 Main
 # ======================================================================
 def main():
     print("🌍 Building consolidated KPI dataset (split + gzip)…")
 
-    meta = load_json(META_PATH)
+    meta = read_json(META_PATH, default=[])
     if not meta:
         print("❌ No meta loaded – aborting.")
         return
@@ -115,7 +97,6 @@ def main():
     }
 
     safe_write_json(index_path, index_data)
-
     print(f"📄 Index written → {index_path}")
     print(f"✅ Done ({len(parts)} parts total).")
 

--- a/scripts/fetch_overall_ranking.py
+++ b/scripts/fetch_overall_ranking.py
@@ -9,11 +9,10 @@
 • Fortschritts- und Fehler-Output
 """
 
-import json
 import subprocess
 from pathlib import Path
 
-from script_utils import ensure_utf8_stdout, safe_write_json, setup_logger
+from script_utils import ensure_utf8_stdout, read_json, safe_write_json, setup_logger
 
 # ======================================================================
 # 🔧 Pfade (pathlib-Version – robust gegen OS-Unterschiede)
@@ -37,12 +36,6 @@ logger = setup_logger("overall_ranking", LOG_FILE)
 
 def log(message: str) -> None:
     logger.info(message)
-
-
-def load_json(path: Path):
-    with path.open("r", encoding="utf-8") as f:
-        return json.load(f)
-
 def get_latest_values(entries):
     """Findet den neuesten Wert pro Land."""
     latest = {}
@@ -65,7 +58,7 @@ def main():
         log(f"[ERR] Missing {AVAILABLE_FILE}")
         return
 
-    available = load_json(AVAILABLE_FILE)
+    available = read_json(AVAILABLE_FILE, default=[], logger=logger)
     valid_kpis = {}
 
     # === KPI-Auswahl (Filterung) ===
@@ -101,7 +94,7 @@ def main():
             continue
 
         try:
-            data = load_json(filepath)
+            data = read_json(filepath, default=[], logger=logger)
         except Exception as e:
             log(f"⚠️ Could not read {filename}: {e}")
             continue

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -192,8 +192,7 @@ async function populateKpiSelect() {
           !Array.isArray(ALL_DATA[item.id]) ||
           !ALL_DATA[item.id].length
         ) {
-          o.style.color = "gray";
-          o.style.fontStyle = "italic";
+          o.classList.add("option-no-data");
         }
 
         g.appendChild(o);
@@ -700,9 +699,8 @@ function updateTable() {
       tbody.querySelectorAll("tr").forEach(tr => {
         const cell = tr.children[colIndex];
         if (cell) {
-          cell.style.transition = "background 0.3s ease";
-          cell.style.background = "rgba(255,255,0,0.07)";
-          setTimeout(() => (cell.style.background = ""), 300);
+          cell.classList.add("table-highlight");
+          setTimeout(() => cell.classList.remove("table-highlight"), 300);
         }
       });
     }
@@ -934,8 +932,8 @@ async function initMap() {
   }).addTo(map);
 
   // 🩵 Mobile Touch-Fix
-  el.style.touchAction = "pan-x pan-y";
-  document.body.style.overscrollBehavior = "contain";
+  el.classList.add("map-touch-pan");
+  document.body.classList.add("body-overscroll-contain");
   el.addEventListener("touchmove", e => e.stopPropagation(), { passive: true });
 
   setTimeout(() => map.invalidateSize(), 150);
@@ -1202,28 +1200,25 @@ function buildHeatLegendHTML({
   useLog = false
 }) {
   // ✅ Richtige Richtung: Grün = besser
-  const gradientHigher = "linear-gradient(to right, hsl(0,85%,50%), hsl(60,85%,50%), hsl(120,85%,45%))";  // low=rot → high=grün
-  const gradientLower  = "linear-gradient(to right, hsl(120,85%,45%), hsl(60,85%,50%), hsl(0,85%,50%))";  // low=grün → high=rot
-  const gradientTarget = "linear-gradient(to right, hsl(0,85%,50%), #ffffff, hsl(120,85%,45%))";          // Mitte = Ziel
-
-  let bar = gradientHigher;
+  const sortVariant = String(sortMode).toLowerCase();
+  let variant = "higher";
   let modeText = "Higher values = greener";
 
-  switch (String(sortMode).toLowerCase()) {
-    case "higher":
-      bar = gradientHigher;
-      modeText = "Higher values = greener";
-      break;
+  switch (sortVariant) {
     case "lower":
-      bar = gradientLower;
+      variant = "lower";
       modeText = "Lower values = greener";
       break;
     case "target":
-      bar = gradientTarget;
+      variant = "target";
       modeText = `Closer to target (${formatValueAuto(targetVal)} ${unit}) = greener`;
       break;
+    case "higher":
+      variant = "higher";
+      modeText = "Higher values = greener";
+      break;
     default:
-      bar = gradientHigher;
+      variant = "higher";
       modeText = "Quantitative scale (higher = greener)";
   }
 
@@ -1236,12 +1231,12 @@ function buildHeatLegendHTML({
   return `
   <div class="legend-box">
     <div class="legend-title"><strong>${title}</strong></div>
-    <div class="legend-bar" style="background:${bar};"></div>
+    <div class="legend-bar legend-bar--${variant}"></div>
     <div class="legend-scale">
       <span>${minLabel} ${unit}</span>
       <span>${maxLabel} ${unit}</span>
     </div>
-    <div class="legend-mode" style="font-size:0.8em;color:#0a0;">${modeText}</div>
+    <div class="legend-mode legend-mode--${variant}">${modeText}</div>
     ${logInfo}
   </div>`;
 }

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -67,9 +67,11 @@ def safe_write_json(path: Path, data: Any, *, logger: Optional[logging.Logger] =
         logger.info(note or f"JSON written → {path}")
 
 
-def read_json(path: Path, default: Any = None) -> Any:
+def read_json(path: Path, default: Any = None, *, logger: Optional[logging.Logger] = None) -> Any:
     """Read JSON content returning ``default`` on failure."""
     try:
         return json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
+    except Exception as exc:
+        if logger:
+            logger.warning("Could not read %s: %s", path, exc)
         return default

--- a/scripts/script_world.js
+++ b/scripts/script_world.js
@@ -29,13 +29,11 @@ function renderChart(container, title, unit, data) {
   let canvasEl = container.querySelector("canvas");
   if (!canvasEl) {
     canvasEl = document.createElement("canvas");
+    canvasEl.classList.add("chart-canvas");
     container.appendChild(canvasEl);
+  } else {
+    canvasEl.classList.add("chart-canvas");
   }
-
-  canvasEl.style.boxShadow = "0 2px 8px rgba(0,0,0,0.08)";
-  canvasEl.style.borderRadius = "8px";
-  canvasEl.style.marginBottom = "1rem";
-  canvasEl.style.background = "#fff";
 
   const chart = renderLineChart(canvasEl, {
     labels: data.years,
@@ -131,8 +129,7 @@ async function renderWorldKpi(container, kpi) {
       c.remove();
     });
     const msg = document.createElement("p");
-    msg.style.color = "#666";
-    msg.style.fontStyle = "italic";
+    msg.className = "kpi-message";
     msg.textContent = "No data available.";
     block.appendChild(msg);
     return;
@@ -145,8 +142,7 @@ async function renderWorldKpi(container, kpi) {
       c.remove();
     });
     const msg = document.createElement("p");
-    msg.style.color = "#666";
-    msg.style.fontStyle = "italic";
+    msg.className = "kpi-message";
     msg.textContent = "No global values in dataset.";
     block.appendChild(msg);
     return;
@@ -173,8 +169,19 @@ async function renderWorldKpi(container, kpi) {
   source.className = "chart-source";
   if (kpi.source) {
     try {
-      const hostname = new URL(kpi.source).hostname.replace("www.", "");
-      source.innerHTML = `Source: <a href="${kpi.source}" target="_blank" rel="noopener">${hostname}</a>`;
+      const url = new URL(kpi.source, window.location.href);
+      if (["http:", "https:"].includes(url.protocol)) {
+        const hostname = url.hostname.replace(/^www\./, "");
+        const link = document.createElement("a");
+        link.href = url.href;
+        link.target = "_blank";
+        link.rel = "noopener";
+        link.textContent = hostname;
+        source.textContent = "Source: ";
+        source.appendChild(link);
+      } else {
+        source.textContent = `Source: ${kpi.source}`;
+      }
     } catch {
       source.textContent = `Source: ${kpi.source}`;
     }
@@ -214,7 +221,11 @@ async function initWorldPage() {
     }
 
     if (Object.keys(grouped).length === 0) {
-      worldContainer.innerHTML = `<p style="text-align:center;margin-top:2rem;">No global KPIs found.</p>`;
+      worldContainer.innerHTML = "";
+      const emptyMsg = document.createElement("p");
+      emptyMsg.className = "world-empty";
+      emptyMsg.textContent = "No global KPIs found.";
+      worldContainer.appendChild(emptyMsg);
       return;
     }
 
@@ -235,9 +246,7 @@ async function initWorldPage() {
 
         const h2 = document.createElement("h2");
         h2.textContent = cluster;
-        h2.style.margin = "2rem auto 1rem";
-        h2.style.textAlign = "center";
-        h2.style.color = "var(--steel-blue)";
+        h2.className = "world-cluster-title";
         clusterSection.appendChild(h2);
 
         worldContainer.appendChild(clusterSection);

--- a/style.css
+++ b/style.css
@@ -175,11 +175,125 @@ main { flex: 1; position: relative; display: flex; flex-direction: column; }
   line-height: 1.5;
 }
 
+.table-placeholder,
+.table-status {
+  text-align: center;
+  color: #555;
+  font-size: 0.9rem;
+}
+
+.table-status {
+  margin-top: 1rem;
+}
+
+.table-status--error {
+  color: #c0392b;
+}
+
+.chart-canvas {
+  width: 100%;
+  max-width: 900px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  margin-bottom: 1rem;
+}
+
+.kpi-message {
+  color: #666;
+  font-style: italic;
+  text-align: center;
+  margin: 1rem 0;
+}
+
+.world-cluster {
+  max-width: 1100px;
+  margin: 0 auto 2rem;
+  padding: 0 1.5rem 1rem;
+}
+
+.world-cluster-title {
+  margin: 2rem auto 1rem;
+  text-align: center;
+  color: var(--steel-blue);
+}
+
+.world-empty {
+  text-align: center;
+  margin: 2rem 0;
+  color: #666;
+}
+
+.option-no-data {
+  color: #666;
+  font-style: italic;
+}
+
+.table-highlight {
+  background: rgba(255, 255, 0, 0.12);
+  transition: background 0.3s ease;
+}
+
+.map-touch-pan {
+  touch-action: pan-x pan-y;
+}
+
+.body-overscroll-contain {
+  overscroll-behavior: contain;
+}
+
+.legend-bar {
+  height: 12px;
+  border-radius: 999px;
+  margin: 0.5rem 0;
+}
+
+.legend-bar--higher {
+  background: linear-gradient(to right, hsl(0, 85%, 50%), hsl(60, 85%, 50%), hsl(120, 85%, 45%));
+}
+
+.legend-bar--lower {
+  background: linear-gradient(to right, hsl(120, 85%, 45%), hsl(60, 85%, 50%), hsl(0, 85%, 50%));
+}
+
+.legend-bar--target {
+  background: linear-gradient(to right, hsl(0, 85%, 50%), #ffffff, hsl(120, 85%, 45%));
+}
+
+.legend-mode {
+  font-size: 0.8em;
+  margin-top: 0.25rem;
+}
+
+.legend-mode--higher,
+.legend-mode--target {
+  color: #0a0;
+}
+
+.legend-mode--lower {
+  color: #c0392b;
+}
+
+.legend-note {
+  margin-top: 0.5rem;
+  font-size: 0.8em;
+  color: #666;
+}
+
+#world-kpis .graph-block {
+  margin: 0 auto;
+  width: 100%;
+  max-width: 900px;
+  padding: 1rem 1.25rem 1.5rem;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
 
 #data-table,
 #chart-container,
-#map-section,
-#world-kpis {
+#map-section {
   text-align: center;
 }
 
@@ -412,7 +526,15 @@ body.overall-page #legend .missing-kpis span {
 #world-intro { max-width: 900px; margin: 2rem auto 3rem; text-align: center; line-height: 1.6; padding: 0 1rem; }
 
 
-#world-kpis { display: flex; flex-direction: column; align-items: center; gap: 2rem; padding: 0 1rem; max-width: 1100px; margin: 0 auto 3rem; }
+#world-kpis {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 0 1.5rem 3rem;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 1200px;
+}
 
 
 .graph-block { width: 100%; max-width: 1000px; background: #fff; border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1rem 1.5rem; text-align: center; box-shadow: 0 0 10px #0000d; }
@@ -532,7 +654,8 @@ body:not(.overall-page) #controls select { flex: 1 1 auto; padding: .4rem .6rem;
 #glossary-container thead th { background: var(--table-head); color: var(--table-head-text); position: static; }
 
 
-td.outlier { background: #f0014; font-weight: 600; }
+td.outlier,
+.outlier { background: #f0014; font-weight: 600; }
 
 
 td.warn { background: #ffa50014; }
@@ -561,22 +684,6 @@ body.world-page,body.world-page * { font-family: "Segoe UI",Roboto,Arial,sans-se
 
 #site-logo { height: 100%; width: auto; object-fit: contain; image-rendering: crisp-edges; }
 
-
-*/
-.leaflet-container { touch-action: pan-x pan-y!important; }
-
-
-.map-container { height: auto !important; overflow: visible !important; }
-
-
-body,html { overscroll-behavior: contain; }
-
-
-
-canvas { max-width: 100%!important; height: auto!important; }
-
-
-.chart-selects { display: flex; flex-direction: column; gap: .3rem; max-width: 280px; margin: .5rem auto 1rem; }
 
 
 .chart-selects select { width: 100%; padding: .45rem .5rem; border: 1px solid #ccc; border-radius: 6px; background: #fafafa; font-size: .95rem; }
@@ -648,7 +755,6 @@ body.world-page { overflow-x: hidden; }
 #logo { height: 40px; width: auto; object-fit: contain; display: block; margin-bottom: .5rem; content: url("images/logo.png"); max-height: 70px; border-radius: 50%; transition: transform .3s ease; }
 
 
-*/
 #about-section { max-width: 900px; margin: 2rem auto 4rem; padding: 0 1.5rem; line-height: 1.6; }
 
 
@@ -679,11 +785,9 @@ body.world-page { overflow-x: hidden; }
 .chart-source a:hover { text-decoration: underline; }
 
 
-*/
 @supports (-webkit-touch-callout: none) { #logoheight: auto!important; max-height: 48px!important; margin: .4rem 0; }
 
 
-*/
 tr.fun-mode { background-color: #fff7cc!important; }
 
 
@@ -774,17 +878,6 @@ tr.fun-mode,tr.safe-mode,tr.fun-safe { background: transparent!important; }
 
 #overlay-spinner.hidden { opacity: 0; pointer-events: none; }
 
- */
-/* #spinner { display: inline-block; width: 20px; height: 20px; border: 3px solid #ccc; border-top: 3px solid var(--accent); border-radius: 50%; animation: spin 1s linear infinite; margin-left: 6px; vertical-align: middle; visibility: hidden; }
-
-
-#spinner.active { visibility: visible; }
-
-
-to { transform: rotate(360deg); }
-
- */
-
 /* ============================================================
    🌍 REALITYCHECK – STRUCTURE + RESPONSIVE FIX v9 (2025-11-01)
    Zentrierung • Tables • Charts • Map • Spinner • Logo
@@ -803,7 +896,7 @@ to { transform: rotate(360deg); }
 
 /* === 2️⃣ Allgemeine Container-Zentrierung === */
 #controls, #data-table, #data-meta, #chart-container,
-#map-section, #legend, #world-kpis {
+#map-section, #legend {
   margin: 1.2rem auto;
   max-width: 1100px;
   width: 100%;
@@ -948,38 +1041,6 @@ to { transform: rotate(360deg); }
   height: auto !important;
   display: block;
   margin: 0 auto;
-}
-
-
-
-/* === World KPI Section === */
-#world-kpis {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1.6rem;
-}
-
-
-#world-kpis .graph-block {
-  max-width: 900px;
-  padding: 1rem;
-  border-radius: 10px;
-  background: #fff;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
-}
-
-
-
-/* ============================================================
-   MAP
-   ============================================================ */
-
-#map-section {
-  max-width: 900px;
-  text-align: center;
-  margin: 2rem auto;
-  padding: 0 1rem;
 }
 
 

--- a/world.html
+++ b/world.html
@@ -39,8 +39,8 @@
   <section id="world-kpis"></section>
 
   <!-- ⚠️ AI-Disclaimer -->
-  <p style="text-align:center;font-size:0.85rem;color:#555;margin:1.5rem auto 2rem;max-width:900px;line-height:1.5;">
-    ⚠️ Interpretations and summaries on this page may include AI-generated content derived from publicly available datasets.  
+  <p class="page-disclaimer">
+    ⚠️ Interpretations and summaries on this page may include AI-generated content derived from publicly available datasets.
     Data accuracy and rights remain with the original publishers (World Bank, UN, OWID, etc.).
   </p>
 


### PR DESCRIPTION
## Summary
- replace inline world and ranking disclaimers with reusable CSS classes and restructure world KPI rendering to rely on class-based styling and safe link construction
- clean style.css by adding utility classes, consolidating world KPI layout styles, and removing redundant or conflicting rules for tables, legends, and map handling
- centralize shared helpers by reusing loadJSON from core/chat, refactoring glossary table building to DOM-safe code, and using script_utils.read_json/safe_write_json across Python scripts

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917af8bf138832db98c9791133365c9)