### PR TITLE
Center countries map tooltip header

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -1164,7 +1164,10 @@ async function updateMap() {
                                                 <div class="map-tooltip__title">${cname}</div>
                                         </div>
                                         <div class="map-tooltip__value">${displayValue}</div>
-                                        <div class="map-tooltip__meta">Capital: ${info.capital || "–"} | Gov: ${info.government || "–"}</div>
+                                        <div class="map-tooltip__meta">
+                                                <div class="map-tooltip__meta-row">Capital: ${info.capital || "–"}</div>
+                                                <div class="map-tooltip__meta-row">Gov: ${info.government || "–"}</div>
+                                        </div>
                                 </div>
                         `;
 			layer.bindTooltip(tooltip, { sticky: true });

--- a/style.css
+++ b/style.css
@@ -1768,12 +1768,14 @@ header#main-header nav a.active {
   display: grid;
   gap: 0.35rem;
   max-width: 220px;
+  text-align: center;
 }
 
 .map-tooltip__header {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.35rem;
 }
 
 .map-tooltip__flag {
@@ -1794,8 +1796,14 @@ header#main-header nav a.active {
 }
 
 .map-tooltip__meta {
+  display: grid;
+  gap: 0.25rem;
   font-size: 0.75rem;
   color: #444;
+}
+
+.map-tooltip__meta-row {
+  white-space: normal;
 }
 
 /* 📱 Mobile Pure Icon Mode (nur Emojis sichtbar, Tooltip via title) */


### PR DESCRIPTION
## Summary
- center the map tooltip header so the flag and country name align vertically
- split capital and government details into separate rows to avoid overflow
- adjust tooltip styling to match the new structure

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69184a49433c832db49c2ede5078d8f5)