### PR TITLE
Handle ISO codes in CSV fetch

### DIFF
--- a/scripts/fetch_data.py
+++ b/scripts/fetch_data.py
@@ -269,7 +269,23 @@ def _norm(s: str) -> str:
     return re.sub(r"[^a-z0-9]+", "", s)
 
 def build_country_indices(countries: Dict[str, Any], mapping: Dict[str, str]):
-    c_index = { _norm(k): k for k in countries.keys() }
+    """Create lookup tables for canonical names and aliases.
+
+    Besides normalized country names we now also index ISO2/ISO3 codes so that
+    CSV sources which only provide codes (e.g. "AFG" or "DE") are resolved
+    without requiring manual aliases.
+    """
+
+    c_index = {}
+    for cname, meta in (countries or {}).items():
+        c_index[_norm(cname)] = cname
+
+        if isinstance(meta, dict):
+            for key in ("iso_a2", "iso2", "alpha2", "iso_a3", "iso3", "alpha3"):
+                code = meta.get(key)
+                if code:
+                    c_index[_norm(code)] = cname
+
     a_index = {}
     for alias, target in (mapping or {}).items():
         if not target or str(target).strip() == "":
@@ -286,6 +302,9 @@ def canonicalize_country(name: str, c_index, a_index, countries, pending, stats)
         stats["mapped_ok"] += 1
         return name
     n = _norm(name)
+    if n in c_index:
+        stats["mapped_ok"] += 1
+        return c_index[n]
     if n in a_index:
         target = a_index[n]
         if target == "":


### PR DESCRIPTION
## Summary
- index ISO2/ISO3 codes in `build_country_indices` so CSV sources that only list codes map to the right country
- resolve normalized country identifiers directly from the primary index before falling back to aliases

## Testing
- `python - <<'PY'
import types, sys
sys.path.append('scripts')
requests_stub = types.ModuleType('requests')
requests_stub.get = lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError('requests stub used'))
sys.modules['requests'] = requests_stub
env_stub = types.ModuleType('env_utils')
env_stub.get_openai_key = lambda: None
sys.modules['env_utils'] = env_stub
import fetch_data as fd
from collections import defaultdict
countries = fd.load_json_file(fd.META_DIR / 'countries.json')
country_map = fd.load_json_file(fd.META_DIR / 'country_mappings.json')
ci, ai = fd.build_country_indices(countries, country_map)
stats = defaultdict(int)
pending = {}
print('AFG ->', fd.canonicalize_country('AFG', ci, ai, countries, pending, stats))
print('DE ->', fd.canonicalize_country('DE', ci, ai, countries, pending, stats))
print('France ->', fd.canonicalize_country('France', ci, ai, countries, pending, stats))
PY`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918ffb89dcc832da4b891dba59ea512)