### PR TITLE
Centralize GPT prompts and harden JSON tooling

### DIFF
--- a/scripts/analysis.py
+++ b/scripts/analysis.py
@@ -22,6 +22,10 @@ except Exception:
     def tqdm(x, **k): return x
 
 from env_utils import get_openai_client
+from prompt_templates import (
+    build_global_analysis_prompt,
+    build_kpi_summary_prompt,
+)
 from script_utils import ensure_utf8_stdout, safe_write_json, safe_write_text, setup_logger
 
 # === UTF-8 ===
@@ -133,33 +137,7 @@ def run_global_analysis(updated):
     if not summaries:
         txt="⚠️ No KPI values found."; safe_write_text(OUT_MD,txt); safe_write_json(OUT_JSON,{"summary":txt}); return
     joined="\n".join(summaries)
-    prompt = f"""
-You are a senior geopolitical and socio-economic analyst preparing a comprehensive synthesis of global KPI trends.
-
-Your task: write a **structured, insightful, and readable report** (8–10 clearly separated sections) interpreting
-cross-domain patterns across economy, environment, society, governance, and technology, based on these aggregated KPIs:
-
-{joined}
-
-**Formatting requirements:**
-• Use Markdown with clear section headers (## Economy, ## Environment, ## Society & Governance, ## Technology, ## Regional Insights, ## Outlook, etc.).
-• Use short paragraphs (max 5 lines each).
-• Add bullet points or numbered lists when summarizing contrasts or correlations.
-• Highlight key figures, countries, or anomalies in **bold**.
-• Avoid walls of text — readability and structure are essential.
-
-**Analytical focus:**
-- Major global progress and regression trends  
-- Interconnections between indicators (e.g., GDP ↔ CO₂, democracy ↔ happiness)  
-- Contrasts between democracies vs autocracies, and rich vs poor countries  
-- Regional differences (Europe, Africa, Asia, Americas)  
-- Long-term implications, risks, and opportunities  
-- Noteworthy outliers or anomalies  
-- A forward-looking outlook (climate, stability, prosperity)
-
-Style: clear, engaging, and accessible English (B2 level).  
-Be factual but interpretative, analytical but not technical.
-"""
+    prompt = build_global_analysis_prompt(summaries)
 
     try:
         text = gpt_call(prompt, 2500)
@@ -189,11 +167,12 @@ def generate_kpi_analyses(data_dir: Path, updated_only=None):
         desc=e.get("description","")
         cluster=e.get("cluster","")
         unit=e.get("unit","")
-        prompt=f"""
-Write a concise (≤900 chars) analysis for '{title}' ({cluster}, unit:{unit}).
-Describe what it measures, top/low performers, regional patterns and outlook.
-Context: {desc}
-"""
+        prompt = build_kpi_summary_prompt(
+            title=title,
+            cluster=cluster,
+            unit=unit,
+            description=desc,
+        )
         try: summary=gpt_call(prompt,400)
         except Exception as e: summary=f"⚠️ GPT error: {e}"
         result[fname]={"summary":summary,"last_update":str(date.today())}

--- a/scripts/check_source_csv_updates.py
+++ b/scripts/check_source_csv_updates.py
@@ -8,12 +8,14 @@ Fragt GPT (via OpenAI 1.54.x) ab, ob für CSV-basierte KPIs neuere Versionen exi
 
 import sys
 import json
+import re
 import time
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
 
 from env_utils import get_openai_client
+from prompt_templates import build_csv_update_prompt
 from script_utils import ensure_utf8_stdout, setup_logger
 
 # === UTF-8 ===
@@ -36,42 +38,78 @@ logging.getLogger("openai._client").setLevel(logging.WARNING)
 
 # === OpenAI ===
 # === GPT Lookup ===
-def gpt_lookup_latest_year(title: str, last_year: int) -> int | None:
-    current_year = datetime.now(timezone.utc).year
-    prompt = f"""
-You are a precise data analyst. Determine if there is a newer dataset version.
-Only answer with the **latest available year (YYYY)** or "Unknown".
+def _parse_latest_year_payload(raw: str, *, current_year: int) -> int | None:
+    """Extract a valid year from the JSON payload returned by GPT."""
+    clean = raw.strip().strip("` ")
+    if clean.lower().startswith("json"):
+        clean = clean[4:].strip()
 
-Dataset: "{title}"
-Last known year: {last_year}
-""".strip()
-
+    candidate = clean
     try:
-        client = get_openai_client()
-        rsp = client.chat.completions.create(
-            model="gpt-4-turbo",
-            messages=[
-                {"role": "system", "content": "You are a precise data analyst."},
-                {"role": "user", "content": prompt},
-            ],
-            max_completion_tokens=50
-        )
+        data = json.loads(candidate)
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", clean, re.DOTALL)
+        if not match:
+            return None
+        try:
+            data = json.loads(match.group(0))
+        except json.JSONDecodeError:
+            return None
+
+    latest = data.get("latest_year") if isinstance(data, dict) else None
+    if isinstance(latest, str) and latest.isdigit():
+        latest = int(latest)
+    if isinstance(latest, int) and 1900 < latest <= current_year + 2:
+        return latest
+    return None
+
+
+def gpt_lookup_latest_year(meta: dict, last_year: int | None) -> int | None:
+    current_year = datetime.now(timezone.utc).year
+    title = meta.get("title", "Unknown dataset")
+    source_field = meta.get("source", "")
+    source_url = source_field if isinstance(source_field, str) and source_field.startswith("http") else None
+    publisher = None if source_url else source_field
+
+    prompt = build_csv_update_prompt(
+        title=title,
+        last_year=last_year,
+        source_url=source_url,
+        publisher=publisher,
+        source_code=meta.get("source_code"),
+        description=meta.get("description"),
+    )
+
+    client = get_openai_client()
+    messages = [
+        {"role": "system", "content": "You return JSON only and never hallucinate years."},
+        {"role": "user", "content": prompt},
+    ]
+
+    for attempt in range(2):
+        try:
+            rsp = client.chat.completions.create(
+                model="gpt-4o-mini",
+                messages=messages,
+                max_completion_tokens=200,
+            )
+        except Exception as e:
+            logger.warning(f"⚠️ GPT error for '{title}' (attempt {attempt+1}): {e}")
+            time.sleep(1)
+            continue
+
         text = (rsp.choices[0].message.content or "").strip()
         logger.info(f"🤖 GPT response for '{title}': {text}")
+        parsed_year = _parse_latest_year_payload(text, current_year=current_year)
+        if parsed_year is not None:
+            return parsed_year
 
-        years = [
-            int(s) for s in text.replace(",", " ").split()
-            if s.isdigit() and 1900 < int(s) <= current_year + 2
-        ]
-        if years:
-            return max(years)
-        if "unknown" in text.lower():
-            return None
-        return None
+        messages.append({
+            "role": "user",
+            "content": "Your previous reply was invalid or missing `latest_year`. Reply again with JSON only.",
+        })
 
-    except Exception as e:
-        logger.warning(f"⚠️ GPT error for '{title}': {e}")
-        return None
+    return None
 
 
 # === Main ===
@@ -93,7 +131,7 @@ def main():
         last_year = int((fetch_status.get("kpis", {}).get(fname, {}).get("data_year") or 0))
 
         logger.info(f"🔍 Checking '{title}' (last known year: {last_year or 'None'})")
-        latest = gpt_lookup_latest_year(title, last_year)
+        latest = gpt_lookup_latest_year(meta, last_year or None)
         time.sleep(3)
 
         if latest is None:

--- a/scripts/generate_fun_safe_rankings.py
+++ b/scripts/generate_fun_safe_rankings.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 """
 🌍 RealityCheck – Fun, Safe Haven & Immigration Rankings (Nov 2025)
 ─────────────────────────────────────────────
@@ -18,6 +20,11 @@ from pathlib import Path
 from typing import Any, Optional
 
 from env_utils import get_openai_client
+from prompt_templates import (
+    build_fun_ranking_prompt,
+    build_safe_haven_prompt,
+    build_immigration_prompt,
+)
 from script_utils import ensure_utf8_stdout, safe_write_json, setup_logger
 
 # === UTF-8 Fix ===
@@ -50,50 +57,6 @@ def save_json(data, path: Path):
         log(f"❌ Failed to save {path.name}: {e}")
 
 # === Prompts ===
-PROMPT_FUN = """
-You are an analyst generating the **Fun Ranking** – create a JSON list of the Top 10 countries that best match a 'Fun & Easy Living' lifestyle.
-Criteria: pleasant climate (18–26 °C), many sunny days (280-300), few rainy days (60-90), high happiness (e.g. World Happiness Index), low beer price in restaurants (< 3.50 USD). If a country has a city that is listed in the top 5 most livable cities according to the EIU Global Liveability Index, Mercer Quality of Living Index, or Monocle Quality of Life Survey, that country should receive an additional bonus in the fun ranking.
-Return the full, valid JSON array and make sure all brackets are properly closed.
-""".strip()
-
-PROMPT_SAFE = """
-You are an analyst generating the **Safe Haven Ranking** – create a JSON list of the Top 10 safest and most resilient countries to live in.
-Criteria: human rights (e.g. Human Rights Index), low conflict risk (e.g. Geopolitical Risk Index), moderate climate risk (e.g. Climate Risk Index), resilience (e.g. Inform Resilience Index), stable democracy (e.g. Democracy Index).
-Return the full, valid JSON array and make sure all brackets are properly closed.
-""".strip()
-
-PROMPT_IMMIGRATION = f"""
-You are an international migration and labor-mobility analyst.
-
-Your task: Identify and rank the **Top 10 countries that are easiest and most attractive for immigration in {datetime.now().year}**, based on realistic and data-driven reasoning.
-
-Consider these key dimensions:
-• Openness of immigration policies (visa, work permits, permanent residence options)
-• Job opportunities and demand for skilled workers
-• Integration friendliness and social acceptance of migrants
-• Language accessibility (English or major world language)
-• Quality of life and long-term stability
-
-Base your reasoning on global indexes such as:
-– Migration Policy Index
-– Global Talent Competitiveness Index
-– UN Migration Data Portal
-– World Happiness Index
-– Rule of Law, Safety, and Economic Stability
-
-Output STRICTLY as valid JSON array, no comments or text.
-Each entry must have:
-  {{
-    "rank": <int>,
-    "country": "<string>",
-    "reason": "<string>"
-  }}
-Example:
-[
-  {{"rank": 1, "country": "Canada", "reason": "open immigration policies"}},
-  ...
-]
-""".strip()
 
 
 # === Core ===
@@ -124,44 +87,101 @@ def _attempt_json_load(raw_json: str, mode: str) -> Optional[Any]:
         return None
 
 
-def generate_ranking(mode: str, prompt: str, path: Path):
-    log(f"➡️ Generating {mode} via GPT-4-Turbo …")
-    client = get_openai_client()
-    try:
-        response = client.chat.completions.create(
-            model="gpt-4-turbo",
-            messages=[
-                {"role": "system", "content": "You are a geopolitical and socioeconomic analyst."},
-                {"role": "user", "content": prompt},
-            ],
-            max_completion_tokens=1000
-        )
-        text = response.choices[0].message.content.strip()
-    except Exception as e:
-        log(f"❌ GPT request failed in {mode}: {e}")
-        return []
+def _validate_ranking_payload(data: Any) -> tuple[bool, str]:
+    if not isinstance(data, list):
+        return False, "Response is not a JSON array"
+    if len(data) == 0:
+        return False, "JSON array is empty"
+    if len(data) > 10:
+        return False, "JSON array exceeds 10 entries"
 
-    if not text:
-        log(f"⚠️ Empty response for {mode}")
-        return []
+    for entry in data:
+        if not isinstance(entry, dict):
+            return False, "Entry is not an object"
+        rank = entry.get("rank")
+        country = entry.get("country")
+        reason = entry.get("reason")
+        if not isinstance(rank, int):
+            return False, "Missing integer rank"
+        if not isinstance(country, str) or not country.strip():
+            return False, "Missing country string"
+        if not isinstance(reason, str) or not reason.strip():
+            return False, "Missing reason string"
+        if len(reason) > 220:
+            return False, "Reason exceeds 220 characters"
+    return True, ""
 
+
+def _extract_json_snippet(text: str) -> str | None:
     clean = text.strip("` \n")
     if clean.lower().startswith("json"):
         clean = clean[4:].strip()
-
     match = re.search(r"(\[.*\]|\{.*\})", clean, re.DOTALL)
-    if not match:
-        log(f"⚠️ No JSON found in GPT response for {mode}")
-        log(f"Raw excerpt: {clean[:200]}")
-        return []
+    if match:
+        return match.group(1)
+    return clean if clean.startswith("[") else None
 
-    raw_json = match.group(1)
-    parsed = _attempt_json_load(raw_json, mode)
-    if parsed is None:
-        return []
 
-    save_json(parsed, path)
-    return parsed
+def generate_ranking(mode: str, prompt: str, path: Path):
+    log(f"➡️ Generating {mode} via GPT-4o-Mini …")
+    client = get_openai_client()
+    messages = [
+        {"role": "system", "content": "You answer with JSON arrays that follow the requested schema."},
+        {"role": "user", "content": prompt},
+    ]
+
+    for attempt in range(2):
+        try:
+            response = client.chat.completions.create(
+                model="gpt-4o-mini",
+                messages=messages,
+                max_completion_tokens=1000,
+            )
+        except Exception as e:
+            log(f"❌ GPT request failed in {mode} (attempt {attempt+1}): {e}")
+            continue
+
+        text = (response.choices[0].message.content or "").strip()
+        if not text:
+            log(f"⚠️ Empty response for {mode} (attempt {attempt+1})")
+            messages.append({
+                "role": "user",
+                "content": "Reply again with a JSON array matching the schema.",
+            })
+            continue
+
+        snippet = _extract_json_snippet(text)
+        if not snippet:
+            log(f"⚠️ No JSON found in GPT response for {mode}")
+            log(f"Raw excerpt: {text[:200]}")
+            messages.append({
+                "role": "user",
+                "content": "No valid JSON array detected. Reply with array only.",
+            })
+            continue
+
+        parsed = _attempt_json_load(snippet, mode)
+        if parsed is None:
+            messages.append({
+                "role": "user",
+                "content": "Previous JSON was invalid. Provide a clean JSON array only.",
+            })
+            continue
+
+        valid, reason = _validate_ranking_payload(parsed)
+        if not valid:
+            log(f"⚠️ Validation failed for {mode}: {reason}")
+            messages.append({
+                "role": "user",
+                "content": f"Your JSON did not match the schema ({reason}). Return a corrected JSON array.",
+            })
+            continue
+
+        save_json(parsed, path)
+        return parsed
+
+    log(f"❌ Unable to generate valid JSON for {mode} after retries.")
+    return []
 
 # === Main ===
 if __name__ == "__main__":
@@ -170,9 +190,9 @@ if __name__ == "__main__":
     IMMIG = DATA_DIR / "immigration_ranking.json"
 
     log("🎬 Starting Fun, Safe & Immigration ranking generation…")
-    fun = generate_ranking("Fun Mode", PROMPT_FUN, FUN)
-    safe = generate_ranking("Safe Haven Mode", PROMPT_SAFE, SAFE)
-    immigr = generate_ranking("Immigration Mode", PROMPT_IMMIGRATION, IMMIG)
+    fun = generate_ranking("Fun Mode", build_fun_ranking_prompt(), FUN)
+    safe = generate_ranking("Safe Haven Mode", build_safe_haven_prompt(), SAFE)
+    immigr = generate_ranking("Immigration Mode", build_immigration_prompt(datetime.now().year), IMMIG)
 
     if fun and safe and immigr:
         log("✅ All three rankings generated successfully.")

--- a/scripts/prompt_templates.py
+++ b/scripts/prompt_templates.py
@@ -1,0 +1,153 @@
+"""Centralized prompt templates for GPT interactions within RealityCheck scripts."""
+from __future__ import annotations
+
+from datetime import datetime
+from textwrap import dedent
+from typing import Iterable
+
+
+def build_csv_update_prompt(
+    *,
+    title: str,
+    last_year: int | None,
+    source_url: str | None = None,
+    publisher: str | None = None,
+    source_code: str | None = None,
+    description: str | None = None,
+) -> str:
+    """Prompt used for asking GPT about the freshest CSV release year."""
+    source_bits = []
+    if publisher:
+        source_bits.append(f"Publisher: {publisher}")
+    if source_url:
+        source_bits.append(f"Official URL: {source_url}")
+    if source_code:
+        source_bits.append(f"Internal ID: {source_code}")
+    if description:
+        source_bits.append(f"Description: {description.strip()[:400]}")
+    meta_text = "\n".join(source_bits)
+
+    return dedent(
+        f"""
+        You are a meticulous research assistant verifying whether a KPI dataset has a newer public release.
+
+        Dataset title: "{title}"
+        Last ingested year in our system: {last_year if last_year else "unknown"}
+        {meta_text}
+
+        Instructions:
+        1. Use the official publisher link above or otherwise reliable primary sources.
+        2. Determine the latest release year that is currently available to download.
+        3. Only confirm a newer release if a publication, download page or press release explicitly mentions a year > {last_year or "unknown"}.
+        4. If you cannot verify a fresher release, report null and explain why.
+
+        Respond **only** with a compact JSON object using this schema:
+        {{
+          "dataset": "{title}",
+          "latest_year": <integer|null>,
+          "confidence": "high"|"medium"|"low",
+          "evidence": "Short description of the page or report you checked"
+        }}
+        Do not add markdown, explanations, prose or code fences – JSON only.
+        """
+    ).strip()
+
+
+def build_global_analysis_prompt(summary_lines: Iterable[str]) -> str:
+    joined = "\n".join(summary_lines)
+    return dedent(
+        f"""
+        You are a senior geopolitical and socio-economic analyst preparing a comprehensive synthesis of global KPI trends.
+
+        Your task: write a **structured, insightful, and readable report** (8–10 clearly separated sections) interpreting
+        cross-domain patterns across economy, environment, society, governance, and technology, based on these aggregated KPI highlights:
+
+        {joined}
+
+        **Formatting requirements:**
+        • Use Markdown with clear section headers (## Economy, ## Environment, ## Society & Governance, ## Technology, ## Regional Insights, ## Outlook, etc.).
+        • Use short paragraphs (max 5 lines each).
+        • Add bullet points or numbered lists when summarizing contrasts or correlations.
+        • Highlight key figures, countries, or anomalies in **bold**.
+        • Avoid walls of text — readability and structure are essential.
+
+        **Analytical focus:**
+        - Major global progress and regression trends
+        - Interconnections between indicators (e.g., GDP ↔ CO₂, democracy ↔ happiness)
+        - Contrasts between democracies vs autocracies, and rich vs poor countries
+        - Regional differences (Europe, Africa, Asia, Americas)
+        - Long-term implications, risks, and opportunities
+        - Noteworthy outliers or anomalies
+        - A forward-looking outlook (climate, stability, prosperity)
+
+        Style: clear, engaging, and accessible English (B2 level).
+        Be factual but interpretative, analytical but not technical.
+        """
+    ).strip()
+
+
+def build_kpi_summary_prompt(*, title: str, cluster: str, unit: str, description: str) -> str:
+    return dedent(
+        f"""
+        Write a concise (≤900 chars) analysis for '{title}' ({cluster}, unit: {unit}).
+        Describe what it measures, notable high/low performers, regional patterns and a short outlook.
+        Context: {description}
+        """
+    ).strip()
+
+
+def build_fun_ranking_prompt() -> str:
+    return dedent(
+        """
+        You are an analyst generating the **Fun Ranking** – produce a JSON array with the Top 10 countries that best match a 'Fun & Easy Living' lifestyle.
+        Criteria: pleasant climate (18–26 °C), many sunny days (280-300), few rainy days (60-90), high happiness (World Happiness Index) and low beer price in restaurants (< 3.50 USD).
+        Countries that host cities ranked in the top 5 of the EIU Global Liveability Index, Mercer Quality of Living Index, or Monocle Quality of Life Survey should receive a bonus.
+
+        Output rules:
+        - Respond with a JSON array only.
+        - Each entry must include rank (int), country (string), reason (string ≤ 220 chars).
+        - Do not include trailing commas, comments or explanations outside the JSON.
+        """
+    ).strip()
+
+
+def build_safe_haven_prompt() -> str:
+    return dedent(
+        """
+        You are an analyst generating the **Safe Haven Ranking** – produce a JSON array with the Top 10 safest and most resilient countries to live in.
+        Criteria: strong human rights records, low conflict risk, moderate climate risk, high resilience (e.g., INFORM), and stable democracies (e.g., Democracy Index).
+
+        Output rules:
+        - Respond with a JSON array only.
+        - Each entry must include rank (int), country (string), reason (string ≤ 220 chars).
+        - No comments, markdown, prose or code fences.
+        """
+    ).strip()
+
+
+def build_immigration_prompt(year: int | None = None) -> str:
+    target_year = year or datetime.now().year
+    return dedent(
+        f"""
+        You are an international migration and labor-mobility analyst.
+
+        Identify and rank the **Top 10 countries that are easiest and most attractive for immigration in {target_year}**, based on realistic and data-driven reasoning.
+
+        Consider these dimensions:
+        • Openness of immigration policies (visa, work permits, permanent residence)
+        • Job opportunities and demand for skilled workers
+        • Integration friendliness and social acceptance of migrants
+        • Language accessibility (English or another major world language)
+        • Quality of life, rule of law, and long-term stability
+
+        Reference credible sources such as the Migration Policy Index, Global Talent Competitiveness Index, UN Migration Data Portal, World Happiness Index, and Rule of Law metrics.
+
+        Output strictly as valid JSON array – no comments or text – where each entry contains:
+        {{
+          "rank": <int>,
+          "country": "<string>",
+          "reason": "<string ≤ 220 chars>"
+        }}
+        """
+    ).strip()
+


### PR DESCRIPTION
## Summary
- add `scripts/prompt_templates.py` so the CSV checks, analysis pipeline, and fun/safe ranking generator reuse shared, well-documented prompts
- tighten `check_source_csv_updates.py` by feeding GPT richer KPI metadata, requiring JSON replies, and parsing responses robustly before logging potential updates
- update `analysis.py` and `generate_fun_safe_rankings.py` to consume the shared prompts and add retries/validation so GPT outputs are consistently valid JSON

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691913700730832db1fa347c25cff4ac)