### PR TITLE
Refine shared UI helpers and logging

### DIFF
--- a/about.html
+++ b/about.html
@@ -203,7 +203,7 @@
         creativity and structure, ideation and engineering.
       </p>
 
-      <p style="margin-top:1rem;font-style:italic;">
+      <p class="about-note about-note--spaced">
         RealityCheck became what it is today through a unique blend of  
         human insight, conversational development, and AI-assisted engineering.
       </p>
@@ -230,7 +230,7 @@
         The world is not doomed; it’s changing. And we still decide how.
       </p>
 
-      <p style="font-style:italic;">
+      <p class="about-note">
         Built through curiosity, patience, and collaboration –  
         with facts, reason, and optimism. <br><br>
         <b>Carsten Winterling & ChatGPT</b><br>
@@ -248,6 +248,7 @@
 </script>
 
 <!-- 🧠 Shared RealityCheck Core -->
+<script src="scripts/utils_ui.js" defer></script>
 <script src="scripts/core.js" defer></script>
 
 </body>

--- a/analysis.html
+++ b/analysis.html
@@ -55,8 +55,9 @@
       });
   </script>	
 
-	<!-- 🧠 Shared RealityCheck Core -->
-	<script src="scripts/core.js" defer></script>
+        <!-- 🧠 Shared RealityCheck Core -->
+        <script src="scripts/utils_ui.js" defer></script>
+        <script src="scripts/core.js" defer></script>
 	
 </body>
 </html>

--- a/bak/chat.html
+++ b/bak/chat.html
@@ -25,6 +25,7 @@
 <meta charset="UTF-8">
 <title>RealityCheck Chatbot (Demo)</title>
 <link rel="stylesheet" href="style_chat.css">
+<script src="scripts/utils_ui.js" defer></script>
 <script src="scripts/core.js" defer></script>
 <script src="chat_demo.js" defer></script>
 </head>

--- a/countries.html
+++ b/countries.html
@@ -158,6 +158,7 @@
   
   <!-- Footer wird automatisch über core.js geladen -->
   <!-- 🧠 Shared RealityCheck Core -->
+  <script src="scripts/utils_ui.js" defer></script>
   <script src="scripts/core.js" defer></script>
   <script src="scripts/script.js" defer></script>
 

--- a/data_glossary.html
+++ b/data_glossary.html
@@ -264,6 +264,7 @@
   }
   </script>
 
+  <script src="scripts/utils_ui.js" defer></script>
   <script src="scripts/core.js" defer></script>
 </body>
 </html>

--- a/footer.html
+++ b/footer.html
@@ -11,7 +11,7 @@
     <a href="privacy.html">🔒 Privacy</a> |
     <a href="https://github.com/ckvfox/realitycheck" target="_blank" title="View on GitHub"
        rel="noopener noreferrer"
-       style="display:inline-flex;align-items:center;gap:4px;">
+       class="footer-github-link">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"
            width="14" height="14" fill="white" aria-hidden="true">
         <path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 005.47 7.59c.4.07.55-.17.55-.38v-1.32

--- a/impressum.html
+++ b/impressum.html
@@ -49,6 +49,7 @@
   </section>
 	
 <!-- 🧠 Shared RealityCheck Core -->
+<script src="scripts/utils_ui.js" defer></script>
 <script src="scripts/core.js" defer></script>
 
 </body>

--- a/overall_ranking_countries.html
+++ b/overall_ranking_countries.html
@@ -46,10 +46,10 @@
 
 <!-- 🌈 Mode Switch Buttons -->
 <section id="mode-switch">
-  <button id="normalMode" class="mode-button"><span class="emoji">⚙️</span><span>Normal</span></button>
-  <button id="funMode" class="mode-button"><span class="emoji">😎</span><span>Fun</span></button>
-  <button id="safeMode" class="mode-button"><span class="emoji">🛡️</span><span>Safe</span></button>
-  <button id="immigrationMode" class="mode-button"><span class="emoji">🧳</span><span>Immigration</span></button>
+  <button id="normalMode" class="mode-button mode-button--icon-only"><span class="emoji">⚙️</span><span>Normal</span></button>
+  <button id="funMode" class="mode-button mode-button--icon-only"><span class="emoji">😎</span><span>Fun</span></button>
+  <button id="safeMode" class="mode-button mode-button--icon-only"><span class="emoji">🛡️</span><span>Safe</span></button>
+  <button id="immigrationMode" class="mode-button mode-button--icon-only"><span class="emoji">🧳</span><span>Immigration</span></button>
 </section>
 
 
@@ -76,6 +76,7 @@
   <!-- JS -->
   <script src="https://cdn.jsdelivr.net/npm/pako@2.1.0/dist/pako.min.js" defer></script>
         <!-- 🧠 Shared RealityCheck Core -->
+        <script src="scripts/utils_ui.js" defer></script>
         <script src="scripts/core.js" defer></script>
   <script src="scripts/script_overall_ranking_countries.js" defer></script>
 </body>

--- a/privacy.html
+++ b/privacy.html
@@ -86,6 +86,7 @@
   </section>
 	
 <!-- 🧠 Shared RealityCheck Core -->
+<script src="scripts/utils_ui.js" defer></script>
 <script src="scripts/core.js" defer></script>
 
 </body>

--- a/scripts/core.js
+++ b/scripts/core.js
@@ -505,6 +505,16 @@ function calcTrend(current, previous) {
   return "→";
 }
 
+function escapeHTML(value) {
+  if (value === null || value === undefined) return "";
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 // === Deep merge helper (for Chart option overrides) ===
 function deepMerge(target, ...sources) {
   if (!target) target = {};
@@ -565,6 +575,93 @@ function groupKpisByCluster(list, options = {}) {
 }
 
 // === Shared Chart.js renderer ===
+const FALLBACK_CHART_OPTIONS = {
+  responsive: true,
+  maintainAspectRatio: false,
+  layout: { padding: { top: 16, bottom: 12, left: 8, right: 8 } },
+  interaction: { mode: "nearest", intersect: false },
+  plugins: {
+    title: { display: false, text: "" },
+    legend: { display: true },
+    tooltip: {
+      enabled: true,
+      callbacks: {
+        title: ctx => (ctx?.length ? `Year: ${ctx[0].label ?? ""}` : ""),
+        label: ctx => {
+          const datasetLabel = ctx.dataset?.label ? `${ctx.dataset.label}: ` : "";
+          const value = ctx.parsed?.y;
+          if (value == null || isNaN(value)) {
+            return `${datasetLabel}no data`;
+          }
+          return `${datasetLabel}${Number(value).toLocaleString()}`;
+        }
+      }
+    }
+  },
+  scales: {
+    y: { beginAtZero: false, grid: { color: "rgba(0,0,0,0.1)" } },
+    x: {
+      ticks: { autoSkip: true, maxTicksLimit: 12 },
+      grid: { color: "rgba(0,0,0,0.05)" }
+    }
+  }
+};
+
+function cloneChartOptions(obj) {
+  if (!obj) return {};
+  if (typeof structuredClone === "function") {
+    return structuredClone(obj);
+  }
+  try {
+    return JSON.parse(JSON.stringify(obj));
+  } catch {
+    return {};
+  }
+}
+
+function resolveChartOptions({ title = "", unit = "", datasetCount = 0, overrides = {} }) {
+  const base =
+    (typeof window !== "undefined" && window.DEFAULT_CHART_OPTIONS) || FALLBACK_CHART_OPTIONS;
+  const merged = cloneChartOptions(base);
+
+  merged.plugins = merged.plugins || {};
+  merged.plugins.title = merged.plugins.title || { display: false, text: "" };
+  merged.plugins.title.display = !!title;
+  merged.plugins.title.text = title || "";
+
+  if (merged.plugins.legend) {
+    merged.plugins.legend.display = datasetCount > 0;
+  }
+
+  merged.scales = merged.scales || {};
+  merged.scales.y = merged.scales.y || {};
+  merged.scales.y.title = unit
+    ? { display: true, text: unit }
+    : { display: false, text: "" };
+
+  const tooltip = merged.plugins.tooltip || {};
+  merged.plugins.tooltip = tooltip;
+  tooltip.callbacks = tooltip.callbacks || {};
+  const baseLabel = tooltip.callbacks.label;
+  tooltip.callbacks.label = ctx => {
+    if (typeof baseLabel === "function" && !unit) {
+      return baseLabel(ctx);
+    }
+    const datasetLabel = ctx.dataset?.label ? `${ctx.dataset.label}: ` : "";
+    const value = ctx.parsed?.y;
+    if (value == null || isNaN(value)) {
+      return `${datasetLabel}no data`;
+    }
+    const formatted = Number(value).toLocaleString();
+    return unit ? `${datasetLabel}${formatted} ${unit}`.trim() : `${datasetLabel}${formatted}`;
+  };
+  if (!tooltip.callbacks.title) {
+    tooltip.callbacks.title = ctx => (ctx?.length ? `Year: ${ctx[0].label ?? ""}` : "");
+  }
+
+  return deepMerge(merged, overrides || {});
+}
+
 function renderLineChart(canvas, config = {}) {
   if (!canvas || typeof canvas.getContext !== "function") return null;
 
@@ -611,50 +708,13 @@ function renderLineChart(canvas, config = {}) {
       labels: safeLabels,
       datasets: datasets.length ? datasets : [baseFallback]
     },
-    options: {
-      responsive: true,
-      maintainAspectRatio: true,
-      interaction: { mode: "nearest", intersect: false },
-      layout: { padding: { top: 16, bottom: 12, left: 8, right: 8 } },
-      plugins: {
-        title: { display: !!title, text: title },
-        legend: { display: datasets.length > 0 },
-        tooltip: {
-          enabled: true,
-          callbacks: {
-            title: ctx =>
-              ctx?.length ? `Year: ${ctx[0].label ?? ""}` : "",
-            label: ctx => {
-              const datasetLabel = ctx.dataset?.label
-                ? `${ctx.dataset.label}: `
-                : "";
-              const value = ctx.parsed?.y;
-              if (value == null || isNaN(value)) {
-                return `${datasetLabel}no data`;
-              }
-              const formatted = Number(value).toLocaleString();
-              return unit
-                ? `${datasetLabel}${formatted} ${unit}`.trim()
-                : `${datasetLabel}${formatted}`;
-            }
-          }
-        }
-      },
-      scales: {
-        y: {
-          beginAtZero: true,
-          title: { display: !!unit, text: unit || "" },
-          grid: { color: "rgba(0,0,0,0.1)" }
-        },
-        x: {
-          ticks: { autoSkip: true, maxTicksLimit: 12 },
-          grid: { color: "rgba(0,0,0,0.05)" }
-        }
-      }
-    }
+    options: resolveChartOptions({
+      title,
+      unit,
+      datasetCount: datasets.length,
+      overrides: options
+    })
   };
-
-  deepMerge(configObj.options, options);
 
   const ctx = canvas.getContext("2d");
   const chart = new Chart(ctx, configObj);
@@ -807,6 +867,7 @@ window.groupKpisByCluster = groupKpisByCluster;
 window.chooseScaleFromValues = chooseScaleFromValues;
 window.formatValueAuto = formatValueAuto;
 window.calcTrend = calcTrend;
+window.escapeHTML = escapeHTML;
 window.rcLog = rcLog;
 window.loadAllKPIData = loadAllKPIData;
 window.renderLineChart = renderLineChart;

--- a/scripts/fetch_data.py
+++ b/scripts/fetch_data.py
@@ -32,6 +32,7 @@ from script_utils import (
     read_json as load_json_file,
     safe_write_json as write_json_atomic,
     safe_write_text as write_text_atomic,
+    setup_logger,
 )
 
 
@@ -56,6 +57,8 @@ COUNTRY_PENDING_FILE = META_DIR / "country_mappings_pending.json"
 AVAILABLE_FILE       = META_DIR / "available_kpis.json"
 LOG_FILE             = DATA_DIR / "fetch_log.txt"
 STATUS_FILE          = DATA_DIR / "fetch_status.json"
+
+LOGGER = setup_logger("fetch_data", LOG_FILE)
 
 # ======================================================================
 # 🌐 Netzwerk-Header & Requests-Defaults
@@ -175,34 +178,34 @@ def ensure_dirs():
     os.makedirs(DATA_DIR, exist_ok=True)
     os.makedirs(PENDING_DIR, exist_ok=True)
 
-def log(msg: str):
-    ensure_dirs()
-    line = f"[{now_utc()} UTC] {msg}"
-    print(line)
-    with open(LOG_FILE, "a", encoding="utf-8") as f:
-        f.write(line + "\n")
+def log(msg: str, level: str = "info"):
+    level_name = (level or "info").lower()
+    if level_name == "error":
+        LOGGER.error(msg)
+    elif level_name in {"warn", "warning"}:
+        LOGGER.warning(msg)
+    else:
+        LOGGER.info(msg)
 
 
 def write_json(path: str | Path, obj):
     path = Path(path)
-    write_json_atomic(path, obj)
     length = None
     try:
         length = len(obj)
     except Exception:
         length = None
     rel_path = os.path.relpath(path, ROOT_DIR)
+    note = f"JSON written → {rel_path}"
     if length is not None:
-        log(f"[SAFE] JSON written → {rel_path} ({length} entries)")
-    else:
-        log(f"[SAFE] JSON written → {rel_path}")
+        note += f" ({length} entries)"
+    write_json_atomic(path, obj, logger=LOGGER, note=note)
 
 
 def write_text(path: str | Path, content: str):
     path = Path(path)
-    write_text_atomic(path, content or "")
     rel_path = os.path.relpath(path, ROOT_DIR)
-    log(f"[SAFE] Text written → {rel_path}")
+    write_text_atomic(path, content or "", logger=LOGGER, note=f"Text written → {rel_path}")
 
 def safe_float(x) -> Optional[float]:
     try:

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -6,6 +6,8 @@ let ALL_DATA = {};  // consolidated dataset
 let kpis = {}, countries = {}, groups = {}, fetchStatus = {};
 let populationData = [], gdpData = [], areaData = [];
 let currentKpi = null, currentData = [], chartInstance = null;
+let currentYearList = [];
+let currentValueLookup = new Map();
 let map = null, mapLayer = null;
 let userSort = { col: null, asc: false };
 let currentScale = { factor: 1, suffix: "", label: "Exact values" };
@@ -74,6 +76,28 @@ function rebuildRelationLookups() {
   relationLookups.percapita = buildLookupMap(populationData);
   relationLookups.pergdp = buildLookupMap(gdpData);
   relationLookups.perkm2 = buildLookupMap(areaData);
+}
+
+function rebuildCurrentValueLookup(data) {
+  currentYearList = [];
+  currentValueLookup = new Map();
+  if (!Array.isArray(data) || !data.length) return;
+
+  const yearSet = new Set();
+
+  data.forEach(entry => {
+    if (!entry?.country) return;
+    const year = normalizeYear(entry.year);
+    if (year == null) return;
+    yearSet.add(year);
+
+    if (!currentValueLookup.has(entry.country)) {
+      currentValueLookup.set(entry.country, new Map());
+    }
+    currentValueLookup.get(entry.country).set(year, entry);
+  });
+
+  currentYearList = Array.from(yearSet).sort((a, b) => a - b);
 }
 
 /* ========= Init ========= */
@@ -348,8 +372,8 @@ function populateYearSelect() {
   const sel = document.getElementById("yearSelect");
   if (!sel) return;
 
-  const years = Array.isArray(currentData)
-    ? [...new Set(currentData.map(r => r.year))].filter(y => Number.isFinite(y)).sort((a,b) => b - a)
+  const years = currentYearList.length
+    ? [...currentYearList].sort((a, b) => b - a)
     : [];
 
   // Vorherige Auswahl merken (falls z.B. beim KPI-Wechsel vorhanden)
@@ -734,9 +758,7 @@ function updateChart() {
   if (!ctxEl) return;
 
   const meta = getMetaForCurrent() || { title: currentKpi || "Selected KPI", unit: "" };
-  const years = currentData.length
-    ? [...new Set(currentData.map(r => r.year))].sort((a, b) => a - b)
-    : [];
+  const years = currentYearList.length ? [...currentYearList] : [];
 
   const datasets = [];
   const compareSelectIds = ["country1Select", "country2Select", "country3Select"];
@@ -744,9 +766,10 @@ function updateChart() {
     const sel = document.getElementById(id);
     if (!sel || !sel.value) return;
     const country = sel.value;
-    const vals = years.map(y => {
-      const rec = currentData.find(r => r.country === country && r.year === y);
-      return rec ? applyRelation(rec.value, country, rec.year) : null;
+    const countryLookup = currentValueLookup.get(country);
+    const vals = years.map(year => {
+      const record = countryLookup?.get(year);
+      return record ? applyRelation(record.value, country, record.year) : null;
     });
     datasets.push({
       label: country,
@@ -783,28 +806,9 @@ function updateChart() {
       layout: {
         padding: { top: 20, bottom: 10, left: 10, right: 10 }
       },
-      plugins: {
-        title: { text: meta.title || "No data selected" },
-        legend: { display: datasets.length > 0 },
-        tooltip: {
-          callbacks: {
-            label: ctx => {
-              const country = ctx.dataset.label || "";
-              const year = ctx.label;
-              const value = ctx.parsed?.y;
-              if (value == null || isNaN(value)) {
-                return `${country}: no data (${year})`;
-              }
-              return `${country}: ${value.toLocaleString()} (${year})`;
-            },
-            title: ctx => "Year: " + (ctx[0]?.label ?? "")
-          }
-        }
-      },
       scales: {
         y: {
           beginAtZero: true,
-          title: { display: !!(meta.unit || ""), text: meta.unit || "" },
           grid: { color: "rgba(255,255,255,0.05)" }
         },
         x: {
@@ -849,7 +853,8 @@ function updateView() {
 
     const filename = meta.filename || meta.id || meta.title;
 
-	currentData = ALL_DATA[filename] || [];
+        currentData = ALL_DATA[filename] || [];
+        rebuildCurrentValueLookup(currentData);
 
       console.log(`✅ updateView(): ${filename} → ${currentData.length} records`);
 

--- a/scripts/script_overall_ranking_countries.js
+++ b/scripts/script_overall_ranking_countries.js
@@ -376,10 +376,16 @@ function getRelevanceWeight(r) {
 /* ---------- Render Table ---------- */
 function renderOverallTable(list) {
   const tbody = document.querySelector("#overall-table tbody");
-  tbody.innerHTML = "";
+  if (!tbody) return;
+  tbody.textContent = "";
 
   if (!list.length) {
-    tbody.innerHTML = `<tr><td colspan="4">No countries meet the 60 % data coverage requirement.</td></tr>`;
+    const tr = document.createElement("tr");
+    const td = document.createElement("td");
+    td.colSpan = 4;
+    td.textContent = "No countries meet the 60 % data coverage requirement.";
+    tr.appendChild(td);
+    tbody.appendChild(tr);
     return;
   }
 
@@ -388,12 +394,23 @@ function renderOverallTable(list) {
     const rank = i + 1;
     const medal = rank === 1 ? "🥇" : rank === 2 ? "🥈" : rank === 3 ? "🥉" : rank;
     const tr = document.createElement("tr");
-    tr.innerHTML = `
-      <td>${medal}</td>
-      <td>${entry.country}</td>
-      <td>${(entry.score * 100).toFixed(2)}</td>
-      <td>${entry.used}</td>
-    `;
+
+    const rankCell = document.createElement("td");
+    rankCell.textContent = medal;
+    tr.appendChild(rankCell);
+
+    const countryCell = document.createElement("td");
+    countryCell.textContent = entry.country;
+    tr.appendChild(countryCell);
+
+    const scoreCell = document.createElement("td");
+    scoreCell.textContent = (entry.score * 100).toFixed(2);
+    tr.appendChild(scoreCell);
+
+    const usedCell = document.createElement("td");
+    usedCell.textContent = entry.used;
+    tr.appendChild(usedCell);
+
     if (rank <= 10) tr.classList.add("top10");
     if (rank > total - 10) tr.classList.add("flop10");
     tbody.appendChild(tr);
@@ -423,10 +440,15 @@ function renderLegend(prioritizedCount, missing = []) {
     wrapper.insertAdjacentElement("afterend", leg);
   }
 
+  const escapeValue =
+    typeof window !== "undefined" && typeof window.escapeHTML === "function"
+      ? window.escapeHTML
+      : value => (value ?? "").toString();
+
   const missingList = missing.length
-    ? `<div class="missing-kpis"><strong>📉 KPIs currently without country-level data:</strong><br><span>${missing.join(
-        ", "
-      )}</span></div>`
+    ? `<div class="missing-kpis"><strong>📉 KPIs currently without country-level data:</strong><br><span>${missing
+        .map(item => escapeValue(item))
+        .join(", ")}</span></div>`
     : "";
 
   leg.innerHTML = `
@@ -484,57 +506,6 @@ function createInfoBox() {
   clearTimeout(box._timeout);
   box._timeout = setTimeout(() => box.classList.remove("show"), 4000);
   setTimeout(() => box.remove(), 5000);
-}
-
-
-/* ---------- Toast Helper (zentriert + Fade + Auto-hide) ---------- */
-function showToast(msg) {
-  // Reuse existing toast element if present
-  let toast = document.getElementById("toast");
-  if (!toast) {
-    toast = document.createElement("div");
-    toast.id = "toast";
-    document.body.appendChild(toast);
-
-    // Basis-Styles (falls CSS fehlt oder noch nicht geladen)
-    Object.assign(toast.style, {
-      position: "fixed",
-      top: "50%",
-      left: "50%",
-      transform: "translate(-50%, -50%) scale(0.9)",
-      background: "rgba(0, 0, 0, 0.8)",
-      color: "#fff",
-      padding: "1rem 1.6rem",
-      borderRadius: "10px",
-      fontSize: "1rem",
-      fontWeight: "500",
-      boxShadow: "0 6px 18px rgba(0,0,0,0.35)",
-      opacity: "0",
-      transition: "opacity 0.4s ease, transform 0.4s ease",
-      zIndex: "99999",
-      pointerEvents: "none",
-      textAlign: "center",
-      maxWidth: "80%"
-    });
-  }
-
-  // Aktualisieren und sichtbar machen
-  toast.textContent = msg;
-  toast.classList.add("show");
-
-  // Animation: Fade-In
-  requestAnimationFrame(() => {
-    toast.style.opacity = "1";
-    toast.style.transform = "translate(-50%, -50%) scale(1)";
-  });
-
-  // Automatisches Ausblenden nach 2.5 s
-  clearTimeout(toast._timeout);
-  toast._timeout = setTimeout(() => {
-    toast.style.opacity = "0";
-    toast.style.transform = "translate(-50%, -50%) scale(0.9)";
-    toast.classList.remove("show");
-  }, 2500);
 }
 
 

--- a/scripts/script_world.js
+++ b/scripts/script_world.js
@@ -54,30 +54,11 @@ function renderChart(container, title, unit, data) {
     existingChart: canvasEl.__rcChart,
     options: {
       plugins: {
-        title: { display: false },
         legend: { display: false },
-        tooltip: {
-          enabled: true,
-          callbacks: {
-            title: ctx => "Year: " + (ctx[0]?.label ?? ""),
-            label: ctx => {
-              const val = ctx.parsed?.y;
-              if (val == null || isNaN(val)) return "No data";
-              return `${val.toLocaleString()} ${unit || ""}`.trim();
-            }
-          }
-        }
+        title: { display: false }
       },
       scales: {
-        y: {
-          beginAtZero: false,
-          title: { display: !!unit, text: unit || "" },
-          grid: { color: "rgba(0,0,0,0.05)" }
-        },
-        x: {
-          ticks: { autoSkip: true, maxTicksLimit: 10 },
-          grid: { color: "rgba(0,0,0,0.05)" }
-        }
+        y: { beginAtZero: false }
       }
     }
   });

--- a/scripts/utils_ui.js
+++ b/scripts/utils_ui.js
@@ -16,40 +16,14 @@ function showToast(msg) {
     toast = document.createElement("div");
     toast.id = "toast";
     document.body.appendChild(toast);
-
-    Object.assign(toast.style, {
-      position: "fixed",
-      top: "50%",
-      left: "50%",
-      transform: "translate(-50%, -50%) scale(0.9)",
-      background: "rgba(0, 0, 0, 0.8)",
-      color: "#fff",
-      padding: "1rem 1.6rem",
-      borderRadius: "10px",
-      fontSize: "1rem",
-      fontWeight: "500",
-      boxShadow: "0 6px 18px rgba(0,0,0,0.35)",
-      opacity: "0",
-      transition: "opacity 0.4s ease, transform 0.4s ease",
-      zIndex: "99999",
-      pointerEvents: "none",
-      textAlign: "center",
-      maxWidth: "80%"
-    });
   }
 
   toast.textContent = msg;
 
   toast.classList.add("show");
-  requestAnimationFrame(() => {
-    toast.style.opacity = "1";
-    toast.style.transform = "translate(-50%, -50%) scale(1)";
-  });
 
   clearTimeout(toast._timeout);
   toast._timeout = setTimeout(() => {
-    toast.style.opacity = "0";
-    toast.style.transform = "translate(-50%, -50%) scale(0.9)";
     toast.classList.remove("show");
   }, 2500);
 }

--- a/style.css
+++ b/style.css
@@ -103,24 +103,22 @@ nav { display: flex; gap: .6rem; align-items: center; flex-wrap: wrap; justify-c
     justify-content: center;
   }
 
-  .translator-launcher {
-    top: 1.875rem;
-    right: 1.875rem;
+  header#main-header nav {
+    flex-wrap: wrap;
+    gap: 0.4rem;
   }
 
-  @supports (top: calc(1.875rem + env(safe-area-inset-top))) {
-    .translator-launcher {
-      top: calc(1.875rem + env(safe-area-inset-top));
-      right: calc(1.875rem + env(safe-area-inset-right));
-    }
+  header#main-header nav a {
+    font-size: 0.85rem;
+    padding: 0.25rem 0.4rem;
+    white-space: nowrap;
   }
+
+  #logo-text {
+    font-size: 1.1rem;
+  }
+
 }
-
-
-nav a { color: var(--link-muted); font-weight: 500; }
-
-
-nav a:hover,nav a.active { color: var(--link-hover); font-weight: 700; text-decoration: underline; }
 
 
 main { flex: 1; position: relative; display: flex; flex-direction: column; }
@@ -173,6 +171,29 @@ main { flex: 1; position: relative; display: flex; flex-direction: column; }
   margin: 1.5rem auto 2rem;
   max-width: 900px;
   line-height: 1.5;
+}
+
+.footer-github-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: inherit;
+  text-decoration: none;
+}
+.footer-github-link svg {
+  flex-shrink: 0;
+}
+.footer-github-link:hover span {
+  text-decoration: underline;
+}
+
+.about-note {
+  font-style: italic;
+  color: #555;
+  line-height: 1.5;
+}
+.about-note--spaced {
+  margin-top: 1rem;
 }
 
 .table-placeholder,
@@ -1593,6 +1614,22 @@ footer#site-footer {
   margin-top: auto;
   flex-shrink: 0;
 }
+
+@media (max-width: 720px) {
+  footer#site-footer p {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem;
+    line-height: 1.4;
+    font-size: 0.85rem;
+    margin: 0.4rem auto 0;
+  }
+
+  footer#site-footer a {
+    white-space: nowrap;
+  }
+}
 /* === Footer fix: always at bottom of iframe page === */
 html, body {
   min-height: 100vh;
@@ -1675,73 +1712,6 @@ header#main-header nav a.active {
 }
 
 
-/* ============================================================
-🎛️ Mode Buttons – Equal Size + Centered
-============================================================ */
-
-.mode-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 1rem;
-  margin: 1.5rem 0;
-}
-
-.mode-button {
-  display: inline-flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  width: 110px;
-  height: 110px;
-  border-radius: 50%;
-  border: none;
-  background: #1a355e;
-  color: #fff;
-  font-size: 0.85rem;
-  text-align: center;
-  line-height: 1.3;
-  cursor: pointer;
-  transition: transform 0.25s ease, background 0.3s ease;
-  padding: 0.5rem;
-}
-
-.mode-button:hover {
-  transform: scale(1.07);
-  background: #244a8f;
-}
-
-.mode-button.active {
-  background: #0078d4;
-  color: #fff;
-  box-shadow: 0 0 10px rgba(0,120,212,0.5);
-}
-
-/* 📱 Mobile: kompakte Buttons mit Symbol + kurzem Label */
-@media (max-width: 600px) {
-  .mode-button {
-    border-radius: 10px;
-    width: 80px;
-    height: 80px;
-    font-size: 0.9rem;
-    line-height: 1.2;
-    padding: 0.4rem;
-    white-space: normal;
-  }
-
-  .mode-button span {
-    display: block;
-    font-size: 0.8rem;
-    line-height: 1.1;
-    margin-top: 0.15rem;
-  }
-
-  .mode-button .emoji {
-    font-size: 1.5rem;
-    display: block;
-  }
-}
 
 /* ============================================================
 💬 Mobile Mode Tooltip (Floating Bubble)
@@ -1806,28 +1776,6 @@ header#main-header nav a.active {
   white-space: normal;
 }
 
-/* 📱 Mobile Pure Icon Mode (nur Emojis sichtbar, Tooltip via title) */
-@media (max-width: 600px) {
-  .mode-button {
-    width: 70px;
-    height: 70px;
-    border-radius: 50%;
-    padding: 0;
-    font-size: 1.6rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .mode-button span {
-    display: none !important;
-  }
-
-  .mode-button .emoji {
-    font-size: 1.8rem;
-    line-height: 1;
-  }
-}
 
 /* ============================================================
 🩵 Scroll-to-top Button – Always Above Footer
@@ -1916,7 +1864,7 @@ header#main-header nav a.active {
 }
 
 /* ============================================================
-🌈 MODE SWITCH BUTTONS – FINAL CONSISTENT (Desktop + Mobile)
+🌈 Mode Switch Buttons (single source of truth)
 ============================================================ */
 #mode-switch {
   display: flex;
@@ -1926,259 +1874,84 @@ header#main-header nav a.active {
   margin: 1.5rem auto;
 }
 
-/* Desktop */
 .mode-button {
-  background: var(--steel-blue);
-  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
   border: none;
-  border-radius: 10px;
-  padding: 10px 18px;
+  background: #102542;
+  color: #fff;
   font-weight: 600;
   font-size: 1rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.3rem;
   cursor: pointer;
-  transition: background 0.25s ease, transform 0.15s ease;
+  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  overflow: visible;
+  -webkit-text-size-adjust: 100%;
 }
-.mode-button:hover { background: var(--accent); transform: translateY(-1px); }
-.mode-button.active { background: #2196f3; box-shadow: 0 0 10px rgba(33,150,243,0.4); }
 
-/* Emoji inside buttons (desktop baseline) */
 .mode-button .emoji {
-  font-size: 1.3rem;
+  font-size: 1.2rem;
   line-height: 1;
 }
 
-/* ============================================================
-📱 MOBILE (≤640px): round buttons with visible icons
-============================================================ */
+.mode-button:hover {
+  transform: translateY(-1px);
+  background: var(--accent);
+}
+
+.mode-button.active {
+  background: #2196f3;
+  box-shadow: 0 0 12px rgba(33,150,243,0.45);
+}
+
+@media (max-width: 720px) {
+  .mode-button {
+    padding: 0.55rem 0.9rem;
+    font-size: 0.95rem;
+  }
+}
+
 @media (max-width: 640px) {
   .mode-button {
-    width: 64px;
-    height: 64px;
+    width: 78px;
+    height: 78px;
     border-radius: 50%;
-    padding: 0;
     flex-direction: column;
-    font-size: 1.6rem;
-    background: #0b2345;
-    overflow: visible;
-  }
-  .mode-button.active {
-    background: #2196f3;
-    box-shadow: 0 0 12px rgba(33,150,243,0.5);
-  }
-  .mode-button .emoji {
-    font-size: 1.6rem;
-    line-height: 1;
-  }
-  .mode-button span:not(.emoji) { display: none; } /* only icon */
-}
-
-/* ============================================================
-🧩 MICRO ICON VISIBILITY FIX – very small devices (<380px)
-============================================================ */
-@media (max-width: 380px) {
-  .mode-button {
-    position: relative;
-    overflow: visible !important; /* prevent Safari clipping */
-    font-size: 1.6rem;
-    line-height: 1 !important;
-    text-align: center;
-  }
-  .mode-button .emoji {
-    font-size: inherit;
-    line-height: 1;
-    transform: translateZ(0); /* Safari repaint fix */
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-}
-/* ============================================================
-   🛟 Mini-Viewport Fallback: erzwinge Icons per ::before (<380px)
-   — keine Änderungen für größere Geräte —
-   ============================================================ */
-@media (max-width: 380px) {
-  #mode-switch .mode-button {
-    position: relative;
-    overflow: visible;       /* kein Clipping */
-    width: 64px;
-    height: 64px;
-    border-radius: 50%;
-    padding: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    line-height: 1;
-  }
-
-  /* Kinder (Text/Emoji) ausblenden – wir zeichnen das Icon per ::before */
-  #mode-switch .mode-button > span { display: none !important; }
-
-  /* zentriertes Fallback-Icon */
-  #mode-switch .mode-button::before {
-    display: inline-block;
-    font-size: 1.6rem;       /* gleiche Größe wie sonst */
-    line-height: 1;
-    transform: translateZ(0);/* Safari-Repaint-Fix */
-    content: "";
-  }
-
-  /* Icons je Button-ID */
-  #normalMode::before      { content: "⚙️"; }
-  #funMode::before         { content: "😎"; }
-  #safeMode::before        { content: "🛡️"; }
-  #immigrationMode::before { content: "🧳"; }
-}
-/* ============================================================
-   🖼️ ICON IMAGE FALLBACK – very small devices (<380px)
-   ============================================================ */
-@media (max-width: 380px) {
-  #mode-switch .mode-button {
-    width: 64px;
-    height: 64px;
-    border-radius: 50%;
-    background-size: cover;
-    background-position: center;
-    background-repeat: no-repeat;
-    border: none;
-    padding: 0;
-    overflow: hidden;
-    box-shadow: none;
-    transition: box-shadow 0.3s ease;
-  }
-
-  /* Hover glow */
-  #mode-switch .mode-button:hover {
-    box-shadow: 0 0 12px rgba(33,150,243,0.6);
-  }
-
-  /* Text & Emoji ausblenden */
-  #mode-switch .mode-button > span { display: none !important; }
-
-  /* Fallback-Bilder */
-  #normalMode      { background-image: url("images/buttons/btn_normal.png"); }
-  #funMode         { background-image: url("images/buttons/btn_fun.png"); }
-  #safeMode        { background-image: url("images/buttons/btn_safe.png"); }
-  #immigrationMode { background-image: url("images/buttons/btn_immigration.png"); }
-
-  /* Active glow */
-  #mode-switch .mode-button.active {
-    box-shadow: 0 0 16px rgba(33,150,243,0.8);
-  }
-}
-/* ============================================================
-📱 REALITYCHECK – MOBILE CONSISTENCY FIX (Nov 2025)
-Fixes: header/menu overflow, footer overflow, disappearing icons
-============================================================ */
-
-/* 1️⃣ HEADER – flexible, wraps cleanly */
-@media (max-width: 720px) {
-  header#main-header nav {
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 0.4rem;
-  }
-  header#main-header nav a {
+    gap: 0.2rem;
     font-size: 0.85rem;
-    padding: 0.25rem 0.4rem;
-    white-space: nowrap;
   }
-  #logo-text {
-    font-size: 1.1rem;
-  }
-}
 
-/* 2️⃣ FOOTER – links wrap within screen */
-@media (max-width: 720px) {
-  footer#site-footer p {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 0.5rem;
-    line-height: 1.4;
-    font-size: 0.85rem;
-    margin: 0.4rem auto 0;
-  }
-  footer#site-footer a {
-    white-space: nowrap;
-  }
-}
-
-/* 3️⃣ MODE BUTTONS – keep emojis visible on iOS Safari */
-#mode-switch .mode-button {
-  overflow: visible !important;     /* critical Safari fix */
-  line-height: 1 !important;
-  -webkit-text-size-adjust: 100%;
-  transform: translateZ(0);         /* force repaint */
-}
-
-#mode-switch .mode-button .emoji {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.6rem;
-  line-height: 1;
-  transform: translateZ(0);
-}
-
-/* Slightly smaller on very narrow devices */
-@media (max-width: 420px) {
-  #mode-switch .mode-button {
-    width: 58px;
-    height: 58px;
+  .mode-button .emoji {
     font-size: 1.5rem;
   }
 }
-/* ============================================================
-📱 RealityCheck – iOS Emoji Visibility Fix (2025-11-09)
-============================================================ */
 
-/* Stelle sicher, dass Emojis innerhalb der Buttons immer sichtbar sind */
-#mode-switch .mode-button {
-  display: flex !important;
-  justify-content: center !important;
-  align-items: center !important;
-  flex-direction: row !important;   /* ← KEIN column mehr → verhindert Emoji-Verschwinden */
-  overflow: visible !important;     /* Safari darf nichts clippen */
-  line-height: 1 !important;
-  -webkit-text-size-adjust: 100% !important;
-  transform: translateZ(0) !important; /* Repaint-Fix */
-  text-rendering: optimizeLegibility;
+@media (max-width: 400px) {
+  .mode-button {
+    width: 64px;
+    height: 64px;
+  }
 }
 
-/* Emoji selbst */
-#mode-switch .mode-button .emoji {
-  display: inline-block !important;
-  font-size: 1.8rem !important;
-  line-height: 1 !important;
-  transform: translateZ(0);
-  margin: 0 !important;
-  padding: 0 !important;
+.mode-button--icon-only {
+  letter-spacing: 0.01em;
 }
 
-/* Beschriftung leicht nach rechts statt unten (mobil lesbar) */
-#mode-switch .mode-button span:not(.emoji) {
-  display: inline-block !important;
-  font-size: 0.8rem;
-  margin-left: 0.15rem;
-}
-
-/* Mobile Optimierung – kleinere Buttons */
 @media (max-width: 640px) {
-  #mode-switch .mode-button {
-    width: 60px;
-    height: 60px;
-    border-radius: 50%;
+  .mode-button--icon-only {
     padding: 0;
+    font-size: 1.8rem;
   }
-  #mode-switch .mode-button span:not(.emoji) {
-    display: none !important; /* Nur Emoji sichtbar */
+
+  .mode-button--icon-only span:not(.emoji) {
+    display: none;
   }
 }
-/* ===== Map Legend under the map (no overlay) ===== */
+
+#map-legend {
 #map-legend {
   margin: 1rem auto 0.5rem;
   text-align: center;
@@ -2292,6 +2065,20 @@ body.glossary-page th.sort-desc::after {
   .translator-launcher {
     top: calc(1.875rem + env(safe-area-inset-top));
     right: calc(1.875rem + env(safe-area-inset-right));
+  }
+}
+
+@media (max-width: 720px) {
+  .translator-launcher {
+    top: 1.5rem;
+    right: 1.5rem;
+  }
+
+  @supports (top: calc(1.5rem + env(safe-area-inset-top))) {
+    .translator-launcher {
+      top: calc(1.5rem + env(safe-area-inset-top));
+      right: calc(1.5rem + env(safe-area-inset-right));
+    }
   }
 }
 

--- a/world.html
+++ b/world.html
@@ -47,6 +47,7 @@
   <!-- JS -->
   <script src="https://cdn.jsdelivr.net/npm/pako@2.1.0/dist/pako.min.js" defer></script>
         <!-- 🧠 Shared RealityCheck Core -->
+        <script src="scripts/utils_ui.js" defer></script>
         <script src="scripts/core.js" defer></script>
   <script src="scripts/script_world.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- consolidate Chart.js defaults inside the shared renderer and reuse them across pages while optimising the comparison chart data lookups for better performance
- remove inline styles and duplicated CSS, introduce reusable classes, and hook all pages up to the shared UI utility script (toast + chart defaults)
- harden the overall ranking UI by sanitising dynamic HTML, and switch the fetcher to the common logger utilities for consistent log handling

## Testing
- `python -m compileall scripts`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69190aa91d44832d9cc3599d113fd95f)