### PR TITLE
Run LPI infrastructure conversion offline

### DIFF
--- a/scripts/convert_lpi_infrastructure.py
+++ b/scripts/convert_lpi_infrastructure.py
@@ -1,8 +1,14 @@
-import pandas as pd
+import re
+from decimal import Decimal, ROUND_HALF_UP
+import xml.etree.ElementTree as ET
 from pathlib import Path
+from zipfile import ZipFile
+
+import pandas as pd
 
 RAW_PATH = Path("scripts/source_raw/International_LPI_from_2007_to_2023_0.xlsx")
 TARGET_PATH = Path("scripts/source_csv/lpi_infrastructure.csv")
+NS = {"main": "http://schemas.openxmlformats.org/spreadsheetml/2006/main"}
 
 
 def select_column(columns, candidates):
@@ -13,20 +19,154 @@ def select_column(columns, candidates):
     raise KeyError(f"None of the expected columns {candidates} were found. Available columns: {list(columns)}")
 
 
+def column_index(cell_reference: str) -> int:
+    match = re.match(r"([A-Z]+)", cell_reference)
+    if not match:
+        raise ValueError(f"Invalid cell reference: {cell_reference}")
+    letters = match.group(1)
+    index = 0
+    for char in letters:
+        index = index * 26 + (ord(char) - ord("A") + 1)
+    return index - 1
+
+
+def load_shared_strings(zfile: ZipFile) -> list[str]:
+    try:
+        shared = ET.fromstring(zfile.read("xl/sharedStrings.xml"))
+    except KeyError:
+        return []
+    return [t.find(".//{http://schemas.openxmlformats.org/spreadsheetml/2006/main}t").text or "" for t in shared]
+
+
+def parse_sheet(zfile: ZipFile, sheet_path: str, shared_strings: list[str]) -> pd.DataFrame:
+    sheet = ET.fromstring(zfile.read(f"xl/{sheet_path}"))
+    rows: list[dict[int, str]] = []
+
+    for row in sheet.findall("main:sheetData/main:row", NS):
+        row_data: dict[int, str] = {}
+        for cell in row.findall("main:c", NS):
+            ref = cell.get("r")
+            if not ref:
+                continue
+            value_elem = cell.find("main:v", NS)
+            if value_elem is None:
+                continue
+            value = value_elem.text
+            if cell.get("t") == "s":
+                value = shared_strings[int(value)]
+            row_data[column_index(ref)] = value
+        if row_data:
+            rows.append(row_data)
+
+    if not rows:
+        return pd.DataFrame()
+
+    header_row_index = 0
+    candidate_values = {
+        "country",
+        "economy",
+        "country or area",
+        "country/area",
+        "country name",
+        "country name ",
+    }
+    for idx, row in enumerate(rows):
+        lowered_values = {str(value).strip().lower() for value in row.values() if value}
+        if lowered_values & candidate_values:
+            header_row_index = idx
+            break
+
+    header_map = rows[header_row_index]
+    headers = {idx: header_map[idx] for idx in sorted(header_map)}
+
+    records = []
+    for row in rows[header_row_index + 1 :]:
+        record = {headers[idx]: row.get(idx, "") for idx in headers}
+        if any(value != "" for value in record.values()):
+            records.append(record)
+
+    return pd.DataFrame(records)
+
+
 def main():
     if not RAW_PATH.exists():
         raise FileNotFoundError(f"Source file not found: {RAW_PATH}")
 
-    df = pd.read_excel(RAW_PATH)
+    with ZipFile(RAW_PATH) as zfile:
+        workbook = ET.fromstring(zfile.read("xl/workbook.xml"))
+        relationships = ET.fromstring(zfile.read("xl/_rels/workbook.xml.rels"))
 
-    country_col = select_column(df.columns, ["country", "economy", "country or area", "country/area", "country name", "country name "])
-    year_col = select_column(df.columns, ["year"])
-    value_col = select_column(df.columns, ["lpi score", "score", "lpi score (1=low to 5=high)", "infrastructure score", "lpi score "])
+        rel_map = {
+            rel.get("Id"): rel.get("Target")
+            for rel in relationships.findall(
+                "{http://schemas.openxmlformats.org/package/2006/relationships}Relationship"
+            )
+        }
 
-    data = df[[country_col, year_col, value_col]].rename(columns={country_col: "country", year_col: "year", value_col: "value"})
+        shared_strings = load_shared_strings(zfile)
+
+        frames = []
+        for sheet in workbook.find("main:sheets", NS):
+            sheet_name = sheet.get("name", "").strip()
+            relationship_id = sheet.get(
+                "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}id"
+            )
+            sheet_target = rel_map.get(relationship_id)
+            if not sheet_target or not sheet_name.isdigit():
+                continue
+
+            year = int(sheet_name)
+            df = parse_sheet(zfile, sheet_target, shared_strings)
+            if df.empty:
+                continue
+
+            country_col = select_column(
+                df.columns,
+                [
+                    "country",
+                    "economy",
+                    "country or area",
+                    "country/area",
+                    "country name",
+                    "country name ",
+                ],
+            )
+            value_col = select_column(
+                df.columns,
+                [
+                    "lpi score",
+                    "score",
+                    "lpi score (1=low to 5=high)",
+                    "infrastructure score",
+                    "lpi score ",
+                ],
+            )
+
+            frames.append(
+                df[[country_col, value_col]]
+                .rename(columns={country_col: "country", value_col: "value"})
+                .assign(year=year)
+            )
+
+    if not frames:
+        raise ValueError("No data extracted from workbook")
+
+    data = pd.concat(frames, ignore_index=True)
     data = data.dropna(subset=["country", "year", "value"])
+
     data["year"] = data["year"].astype(int)
-    data = data.sort_values(["country", "year"]).reset_index(drop=True)
+    data["value"] = pd.to_numeric(data["value"], errors="coerce")
+    data = data.dropna(subset=["value"])
+
+    data["value"] = data["value"].map(
+        lambda val: f"{Decimal(str(val)).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}"
+    )
+
+    data = (
+        data[["country", "year", "value"]]
+        .sort_values(["country", "year"])
+        .reset_index(drop=True)
+    )
 
     TARGET_PATH.parent.mkdir(parents=True, exist_ok=True)
     data.to_csv(TARGET_PATH, index=False)

--- a/scripts/source_csv/lpi_infrastructure.csv
+++ b/scripts/source_csv/lpi_infrastructure.csv
@@ -1,0 +1,1080 @@
+country,year,value
+Afghanistan,2007,1.38
+Afghanistan,2010,2.61
+Afghanistan,2012,2.80
+Afghanistan,2014,2.48
+Afghanistan,2016,2.61
+Afghanistan,2018,2.38
+Afghanistan,2023,1.90
+Albania,2007,2.13
+Albania,2010,3.01
+Albania,2012,3.58
+Albania,2016,3.05
+Albania,2018,3.20
+Albania,2023,2.50
+Algeria,2007,2.82
+Algeria,2010,2.81
+Algeria,2012,2.85
+Algeria,2014,3.04
+Algeria,2016,3.08
+Algeria,2018,2.76
+Algeria,2023,2.50
+Angola,2007,2.83
+Angola,2010,3.01
+Angola,2012,2.59
+Angola,2014,3.02
+Angola,2016,2.59
+Angola,2018,2.59
+Angola,2023,2.10
+Antigua and Barbuda,2023,2.90
+Argentina,2007,3.50
+Argentina,2010,3.82
+Argentina,2012,3.27
+Argentina,2014,3.49
+Argentina,2016,3.47
+Argentina,2018,3.37
+Argentina,2023,2.80
+Armenia,2007,2.63
+Armenia,2010,3.40
+Armenia,2012,3.07
+Armenia,2014,3.00
+Armenia,2016,2.60
+Armenia,2018,2.90
+Armenia,2023,2.50
+Australia,2007,4.10
+Australia,2010,4.16
+Australia,2012,4.05
+Australia,2014,4.00
+Australia,2016,4.04
+Australia,2018,3.98
+Australia,2023,3.70
+Austria,2007,4.44
+Austria,2010,4.08
+Austria,2012,3.79
+Austria,2014,4.04
+Austria,2016,4.37
+Austria,2018,4.25
+Austria,2023,4.00
+Azerbaijan,2007,2.63
+Azerbaijan,2010,3.15
+Azerbaijan,2012,3.23
+Azerbaijan,2014,2.57
+"Bahamas, The",2010,3.46
+"Bahamas, The",2012,2.99
+"Bahamas, The",2014,3.19
+"Bahamas, The",2016,2.93
+"Bahamas, The",2018,2.75
+"Bahamas, The",2023,2.70
+Bahrain,2007,3.00
+Bahrain,2010,3.85
+Bahrain,2012,3.42
+Bahrain,2014,2.80
+Bahrain,2016,3.58
+Bahrain,2018,3.29
+Bahrain,2023,3.50
+Bangladesh,2007,3.33
+Bangladesh,2010,3.46
+Bangladesh,2014,3.18
+Bangladesh,2016,2.90
+Bangladesh,2018,2.92
+Bangladesh,2023,2.60
+Belarus,2007,3.00
+Belarus,2012,2.87
+Belarus,2014,3.05
+Belarus,2016,3.04
+Belarus,2018,3.18
+Belarus,2023,2.70
+Belgium,2007,4.25
+Belgium,2010,4.29
+Belgium,2012,4.20
+Belgium,2014,4.39
+Belgium,2016,4.43
+Belgium,2018,4.41
+Belgium,2023,4.00
+Benin,2007,2.78
+Benin,2010,3.49
+Benin,2012,3.74
+Benin,2014,2.85
+Benin,2016,2.69
+Benin,2018,3.42
+Benin,2023,2.90
+Bhutan,2010,2.99
+Bhutan,2012,2.90
+Bhutan,2014,2.28
+Bhutan,2016,2.70
+Bhutan,2018,2.49
+Bhutan,2023,2.50
+Bolivia,2007,2.81
+Bolivia,2010,3.20
+Bolivia,2012,2.95
+Bolivia,2014,2.60
+Bolivia,2016,2.79
+Bolivia,2018,2.74
+Bolivia,2023,2.40
+Bosnia and Herzegovina,2007,3.00
+Bosnia and Herzegovina,2010,3.18
+Bosnia and Herzegovina,2012,3.61
+Bosnia and Herzegovina,2014,3.44
+Bosnia and Herzegovina,2016,2.94
+Bosnia and Herzegovina,2018,3.21
+Bosnia and Herzegovina,2023,3.00
+Botswana,2010,2.99
+Botswana,2012,3.43
+Botswana,2014,2.94
+Botswana,2016,3.72
+Botswana,2023,3.10
+Brazil,2007,3.10
+Brazil,2010,4.14
+Brazil,2012,3.55
+Brazil,2014,3.39
+Brazil,2016,3.39
+Brazil,2018,3.51
+Brazil,2023,3.20
+Brunei Darussalam,2016,3.19
+Brunei Darussalam,2018,3.17
+Bulgaria,2007,3.56
+Bulgaria,2010,3.18
+Bulgaria,2012,3.56
+Bulgaria,2014,4.04
+Bulgaria,2016,3.31
+Bulgaria,2018,3.31
+Bulgaria,2023,3.20
+Burkina Faso,2007,2.25
+Burkina Faso,2010,2.77
+Burkina Faso,2012,2.67
+Burkina Faso,2014,3.21
+Burkina Faso,2016,3.13
+Burkina Faso,2018,3.04
+Burkina Faso,2023,2.30
+Burundi,2007,2.00
+Burundi,2012,1.67
+Burundi,2014,2.76
+Burundi,2016,3.45
+Burundi,2018,2.17
+Buthan,2007,2.57
+Cambodia,2007,3.05
+Cambodia,2010,2.84
+Cambodia,2012,2.95
+Cambodia,2014,2.75
+Cambodia,2016,3.30
+Cambodia,2018,3.16
+Cambodia,2023,2.40
+Cameroon,2007,3.29
+Cameroon,2010,3.16
+Cameroon,2012,3.19
+Cameroon,2014,2.80
+Cameroon,2016,2.29
+Cameroon,2018,2.57
+Cameroon,2023,2.10
+Canada,2007,4.19
+Canada,2010,4.41
+Canada,2012,4.31
+Canada,2014,4.18
+Canada,2016,4.01
+Canada,2018,3.96
+Canada,2023,4.00
+Central African Republic,2012,3.33
+Central African Republic,2014,2.47
+Central African Republic,2018,2.33
+Central African Republic,2023,2.50
+Chad,2007,2.56
+Chad,2010,3.14
+Chad,2012,2.71
+Chad,2014,3.02
+Chad,2016,2.25
+Chad,2018,2.62
+Chile,2007,3.55
+Chile,2010,3.80
+Chile,2012,3.47
+Chile,2014,3.59
+Chile,2016,3.71
+Chile,2018,3.80
+Chile,2023,3.00
+China,2007,3.68
+China,2010,3.91
+China,2012,3.80
+China,2014,3.87
+China,2016,3.90
+China,2018,3.84
+China,2023,3.70
+Colombia,2007,2.94
+Colombia,2010,3.52
+Colombia,2012,3.45
+Colombia,2014,2.87
+Colombia,2016,3.23
+Colombia,2018,3.17
+Colombia,2023,2.90
+Comoros,2007,2.67
+Comoros,2010,3.23
+Comoros,2012,2.70
+Comoros,2014,2.37
+Comoros,2016,2.82
+Comoros,2018,2.80
+"Congo, Dem, Rep,",2016,2.94
+"Congo, Dem. Rep.",2010,3.20
+"Congo, Dem. Rep.",2012,2.38
+"Congo, Dem. Rep.",2014,2.04
+"Congo, Dem. Rep.",2018,2.69
+"Congo, Dem. Rep.",2023,2.50
+"Congo, Rep,",2016,2.57
+"Congo, Rep.",2010,4.00
+"Congo, Rep.",2012,2.90
+"Congo, Rep.",2014,2.58
+"Congo, Rep.",2018,2.95
+"Congo, Rep.",2023,2.60
+Costa Rica,2007,2.89
+Costa Rica,2010,3.71
+Costa Rica,2012,3.19
+Costa Rica,2014,3.04
+Costa Rica,2016,2.98
+Costa Rica,2018,3.16
+Costa Rica,2023,2.90
+Croatia,2007,3.45
+Croatia,2010,3.22
+Croatia,2012,3.54
+Croatia,2014,3.37
+Croatia,2016,3.39
+Croatia,2018,3.59
+Croatia,2023,3.30
+Cuba,2010,2.41
+Cuba,2012,2.31
+Cuba,2014,2.45
+Cuba,2016,2.51
+Cuba,2018,2.46
+Cuba,2023,2.20
+Cyprus,2007,3.25
+Cyprus,2010,3.44
+Cyprus,2012,3.54
+Cyprus,2014,3.31
+Cyprus,2016,3.79
+Cyprus,2018,3.62
+Cyprus,2023,3.20
+Czech Republic,2007,3.56
+Czech Republic,2010,4.16
+Czech Republic,2012,3.40
+Czech Republic,2014,3.73
+Czech Republic,2016,3.94
+Czech Republic,2018,4.13
+Czech Republic,2023,3.30
+Côte d'Ivoire,2007,3.25
+Côte d'Ivoire,2010,2.73
+Côte d'Ivoire,2012,3.36
+Côte d'Ivoire,2014,3.31
+Côte d'Ivoire,2016,2.71
+Côte d'Ivoire,2018,3.23
+Denmark,2007,4.11
+Denmark,2010,4.38
+Denmark,2012,4.21
+Denmark,2014,4.39
+Denmark,2016,3.92
+Denmark,2018,4.41
+Denmark,2023,4.10
+Djibouti,2007,2.30
+Djibouti,2010,2.67
+Djibouti,2012,2.19
+Djibouti,2014,2.74
+Djibouti,2016,2.69
+Djibouti,2018,3.15
+Djibouti,2023,2.70
+Dominican Republic,2007,2.89
+Dominican Republic,2010,3.85
+Dominican Republic,2012,2.97
+Dominican Republic,2014,3.18
+Dominican Republic,2016,3.06
+Dominican Republic,2018,2.98
+Dominican Republic,2023,2.60
+Ecuador,2007,3.27
+Ecuador,2010,3.55
+Ecuador,2012,3.42
+Ecuador,2014,3.18
+Ecuador,2016,3.23
+Ecuador,2018,3.19
+Egypt,2007,2.85
+"Egypt, Arab Rep,",2016,3.63
+"Egypt, Arab Rep.",2010,3.31
+"Egypt, Arab Rep.",2012,3.39
+"Egypt, Arab Rep.",2014,2.99
+"Egypt, Arab Rep.",2018,3.19
+"Egypt, Arab Rep.",2023,3.10
+El Salvador,2007,3.06
+El Salvador,2010,3.63
+El Salvador,2012,3.08
+El Salvador,2014,2.75
+El Salvador,2016,3.29
+El Salvador,2018,3.10
+El Salvador,2023,2.70
+Equatorial Guinea,2014,2.86
+Equatorial Guinea,2016,2.32
+Equatorial Guinea,2018,2.75
+Eritrea,2007,1.83
+Eritrea,2010,2.21
+Eritrea,2012,2.43
+Eritrea,2014,2.79
+Eritrea,2016,2.50
+Eritrea,2018,2.08
+Estonia,2007,3.35
+Estonia,2010,3.68
+Estonia,2012,3.23
+Estonia,2014,3.55
+Estonia,2016,4.08
+Estonia,2018,3.80
+Estonia,2023,3.60
+Ethiopia,2007,3.67
+Ethiopia,2010,2.65
+Ethiopia,2012,2.54
+Ethiopia,2014,3.17
+Ethiopia,2016,2.37
+Fiji,2010,2.82
+Fiji,2012,3.12
+Fiji,2014,2.97
+Fiji,2016,2.60
+Fiji,2018,2.54
+Fiji,2023,2.30
+Finland,2007,4.18
+Finland,2010,4.08
+Finland,2012,4.10
+Finland,2014,3.80
+Finland,2016,4.14
+Finland,2018,4.28
+Finland,2023,4.20
+France,2007,4.02
+France,2010,4.37
+France,2012,4.02
+France,2014,4.17
+France,2016,4.25
+France,2018,4.15
+France,2023,3.90
+Gabon,2007,2.33
+Gabon,2010,2.87
+Gabon,2012,3.00
+Gabon,2014,2.31
+Gabon,2016,2.52
+Gabon,2018,2.67
+Gabon,2023,2.40
+Gambia,2007,2.50
+"Gambia, The",2010,3.15
+"Gambia, The",2012,2.55
+"Gambia, The",2014,2.46
+"Gambia, The",2018,2.71
+"Gambia, The",2023,2.30
+Georgia,2010,3.08
+Georgia,2012,2.86
+Georgia,2014,3.09
+Georgia,2016,2.80
+Georgia,2018,2.95
+Georgia,2023,2.70
+Germany,2007,4.33
+Germany,2010,4.48
+Germany,2012,4.32
+Germany,2014,4.36
+Germany,2016,4.45
+Germany,2018,4.39
+Germany,2023,4.10
+Ghana,2007,2.50
+Ghana,2010,2.67
+Ghana,2012,2.76
+Ghana,2014,2.86
+Ghana,2016,3.21
+Ghana,2018,2.87
+Ghana,2023,2.50
+Greece,2007,4.13
+Greece,2010,3.49
+Greece,2012,3.32
+Greece,2014,3.50
+Greece,2016,3.85
+Greece,2018,3.66
+Greece,2023,3.70
+Grenada,2023,2.50
+Guatemala,2007,3.23
+Guatemala,2010,3.52
+Guatemala,2012,3.19
+Guatemala,2014,3.24
+Guatemala,2016,2.98
+Guatemala,2018,3.11
+Guatemala,2023,2.60
+Guinea,2007,3.50
+Guinea,2010,3.10
+Guinea,2012,2.50
+Guinea,2014,3.10
+Guinea,2016,2.38
+Guinea,2018,2.04
+Guinea,2023,2.50
+Guinea-Bissau,2007,2.86
+Guinea-Bissau,2010,2.91
+Guinea-Bissau,2012,2.74
+Guinea-Bissau,2014,2.71
+Guinea-Bissau,2016,2.74
+Guinea-Bissau,2018,2.86
+Guinea-Bissau,2023,2.60
+Guyana,2007,2.50
+Guyana,2010,2.70
+Guyana,2012,2.67
+Guyana,2014,2.74
+Guyana,2016,3.12
+Guyana,2018,2.65
+Guyana,2023,2.40
+Haiti,2007,2.60
+Haiti,2010,3.02
+Haiti,2012,2.74
+Haiti,2014,2.63
+Haiti,2016,2.02
+Haiti,2018,2.44
+Haiti,2023,2.10
+Honduras,2007,2.88
+Honduras,2010,3.83
+Honduras,2012,2.90
+Honduras,2014,2.79
+Honduras,2016,2.91
+Honduras,2018,2.83
+Honduras,2023,2.90
+"Hong Kong SAR, China",2012,4.28
+"Hong Kong SAR, China",2014,4.06
+"Hong Kong SAR, China",2016,4.29
+"Hong Kong SAR, China",2018,4.14
+"Hong Kong SAR, China",2023,4.00
+"Hong Kong, China",2007,4.33
+"Hong Kong, China",2010,4.04
+Hungary,2007,3.69
+Hungary,2010,3.52
+Hungary,2012,3.41
+Hungary,2014,4.06
+Hungary,2016,3.88
+Hungary,2018,3.79
+Hungary,2023,3.20
+Iceland,2010,3.27
+Iceland,2012,3.62
+Iceland,2014,3.51
+Iceland,2016,3.88
+Iceland,2018,3.70
+Iceland,2023,3.60
+India,2007,3.47
+India,2010,3.61
+India,2012,3.58
+India,2014,3.51
+India,2016,3.74
+India,2018,3.50
+India,2023,3.40
+Indonesia,2007,3.28
+Indonesia,2010,3.46
+Indonesia,2012,3.61
+Indonesia,2014,3.53
+Indonesia,2016,3.46
+Indonesia,2018,3.67
+Indonesia,2023,3.00
+Iran,2007,2.80
+"Iran, Islamic Rep,",2016,2.81
+"Iran, Islamic Rep.",2010,3.26
+"Iran, Islamic Rep.",2012,2.66
+"Iran, Islamic Rep.",2018,3.36
+"Iran, Islamic Rep.",2023,2.30
+Iraq,2010,2.49
+Iraq,2012,2.77
+Iraq,2014,2.85
+Iraq,2016,2.66
+Iraq,2018,2.72
+Iraq,2023,2.40
+Ireland,2007,4.32
+Ireland,2010,4.47
+Ireland,2012,3.77
+Ireland,2014,4.13
+Ireland,2016,3.94
+Ireland,2018,3.76
+Ireland,2023,3.60
+Israel,2007,3.58
+Israel,2010,3.77
+Israel,2014,4.18
+Israel,2016,4.27
+Israel,2018,3.59
+Israel,2023,3.60
+Italy,2007,3.93
+Italy,2010,4.08
+Italy,2012,4.05
+Italy,2014,4.05
+Italy,2016,4.03
+Italy,2018,4.13
+Italy,2023,3.70
+Jamaica,2007,2.65
+Jamaica,2010,2.82
+Jamaica,2012,2.91
+Jamaica,2014,3.14
+Jamaica,2016,2.64
+Jamaica,2018,2.79
+Jamaica,2023,2.50
+Japan,2007,4.34
+Japan,2010,4.26
+Japan,2012,4.21
+Japan,2014,4.24
+Japan,2016,4.21
+Japan,2018,4.25
+Japan,2023,3.90
+Jordan,2007,3.17
+Jordan,2010,3.39
+Jordan,2012,2.92
+Jordan,2014,3.46
+Jordan,2016,3.34
+Jordan,2018,3.18
+Kazakhstan,2007,2.65
+Kazakhstan,2010,3.25
+Kazakhstan,2012,2.73
+Kazakhstan,2014,3.24
+Kazakhstan,2016,3.06
+Kazakhstan,2018,3.53
+Kazakhstan,2023,2.70
+Kenya,2007,2.92
+Kenya,2010,3.06
+Kenya,2012,2.88
+Kenya,2014,3.58
+Kenya,2016,3.70
+Kenya,2018,3.18
+"Korea, Rep,",2016,4.03
+"Korea, Rep.",2010,3.97
+"Korea, Rep.",2012,4.02
+"Korea, Rep.",2014,4.00
+"Korea, Rep.",2018,3.92
+"Korea, Rep.",2023,3.80
+Kuwait,2007,3.75
+Kuwait,2010,3.70
+Kuwait,2012,3.11
+Kuwait,2014,3.39
+Kuwait,2016,3.51
+Kuwait,2018,3.37
+Kuwait,2023,3.20
+Kyrgyz Republic,2007,2.76
+Kyrgyz Republic,2010,3.10
+Kyrgyz Republic,2012,2.69
+Kyrgyz Republic,2014,2.36
+Kyrgyz Republic,2016,2.72
+Kyrgyz Republic,2018,2.94
+Kyrgyz Republic,2023,2.30
+Lao PDR,2010,3.23
+Lao PDR,2012,2.82
+Lao PDR,2014,2.65
+Lao PDR,2016,2.68
+Lao PDR,2018,2.84
+Lao PDR,2023,2.40
+"Laos, PDR",2007,2.83
+Latvia,2007,3.69
+Latvia,2010,3.72
+Latvia,2012,3.08
+Latvia,2014,4.06
+Latvia,2016,3.62
+Latvia,2018,2.88
+Latvia,2023,3.50
+Lebanon,2007,2.67
+Lebanon,2010,3.97
+Lebanon,2012,3.11
+Lebanon,2014,2.89
+Lebanon,2016,2.86
+Lebanon,2018,3.18
+Lesotho,2007,2.83
+Lesotho,2012,2.73
+Lesotho,2014,2.60
+Lesotho,2016,2.35
+Lesotho,2018,2.70
+Liberia,2007,2.43
+Liberia,2010,3.08
+Liberia,2012,2.84
+Liberia,2014,2.57
+Liberia,2016,2.73
+Liberia,2018,3.25
+Liberia,2023,2.40
+Libya,2010,2.98
+Libya,2012,2.51
+Libya,2014,2.85
+Libya,2016,2.83
+Libya,2018,2.77
+Libya,2023,1.90
+Lithuania,2007,3.40
+Lithuania,2010,3.92
+Lithuania,2012,3.70
+Lithuania,2014,3.60
+Lithuania,2016,4.14
+Lithuania,2018,3.65
+Lithuania,2023,3.40
+Luxembourg,2010,4.58
+Luxembourg,2012,4.19
+Luxembourg,2014,4.71
+Luxembourg,2016,4.80
+Luxembourg,2018,3.90
+Luxembourg,2023,3.60
+Luxemburg,2007,4.00
+Macedonia,2007,2.83
+"Macedonia, FYR",2010,3.10
+"Macedonia, FYR",2012,2.79
+"Macedonia, FYR",2014,2.81
+"Macedonia, FYR",2016,3.13
+"Macedonia, FYR",2018,3.03
+Madagascar,2007,2.67
+Madagascar,2010,2.90
+Madagascar,2012,3.13
+Madagascar,2014,3.07
+Madagascar,2016,2.35
+Madagascar,2018,2.73
+Madagascar,2023,2.30
+Malawi,2007,3.00
+Malawi,2012,3.09
+Malawi,2014,2.99
+Malawi,2018,2.98
+Malaysia,2007,3.95
+Malaysia,2010,3.86
+Malaysia,2012,3.86
+Malaysia,2014,3.92
+Malaysia,2016,3.65
+Malaysia,2018,3.46
+Malaysia,2023,3.60
+Maldives,2010,2.83
+Maldives,2012,2.96
+Maldives,2014,2.51
+Maldives,2016,2.88
+Maldives,2018,3.32
+Mali,2007,2.88
+Mali,2010,2.90
+Mali,2014,2.90
+Mali,2016,2.93
+Mali,2018,2.83
+Mali,2023,2.60
+Malta,2010,3.02
+Malta,2012,3.79
+Malta,2014,3.15
+Malta,2016,3.61
+Malta,2018,3.01
+Malta,2023,3.30
+Mauritania,2007,3.10
+Mauritania,2012,2.60
+Mauritania,2014,2.75
+Mauritania,2016,2.14
+Mauritania,2018,2.68
+Mauritania,2023,2.30
+Mauritius,2007,2.33
+Mauritius,2010,2.91
+Mauritius,2012,3.52
+Mauritius,2014,2.88
+Mauritius,2018,3.00
+Mauritius,2023,2.50
+Mexico,2007,3.40
+Mexico,2010,3.66
+Mexico,2012,3.47
+Mexico,2014,3.57
+Mexico,2016,3.38
+Mexico,2018,3.53
+Mexico,2023,2.90
+Moldova,2007,2.73
+Moldova,2010,3.17
+Moldova,2012,2.74
+Moldova,2014,2.89
+Moldova,2016,3.16
+Moldova,2018,3.17
+Moldova,2023,2.50
+Mongolia,2007,2.25
+Mongolia,2010,2.55
+Mongolia,2012,2.99
+Mongolia,2014,2.51
+Mongolia,2016,3.40
+Mongolia,2018,3.06
+Mongolia,2023,2.50
+Montenegro,2010,2.65
+Montenegro,2012,2.89
+Montenegro,2014,3.19
+Montenegro,2016,2.69
+Montenegro,2018,3.33
+Montenegro,2023,2.80
+Morocco,2007,2.86
+Morocco,2012,3.51
+Morocco,2016,3.20
+Morocco,2018,2.88
+Mozambique,2007,2.83
+Mozambique,2010,2.40
+Mozambique,2014,2.74
+Mozambique,2016,3.04
+Myanmar,2007,2.08
+Myanmar,2010,3.29
+Myanmar,2012,2.59
+Myanmar,2014,2.83
+Myanmar,2016,2.85
+Myanmar,2018,2.91
+Namibia,2007,3.00
+Namibia,2010,2.38
+Namibia,2012,2.52
+Namibia,2014,3.15
+Namibia,2016,3.19
+Namibia,2023,2.90
+Nepal,2007,2.75
+Nepal,2010,2.74
+Nepal,2012,2.21
+Nepal,2014,3.06
+Nepal,2016,2.93
+Nepal,2018,3.10
+Netherlands,2007,4.38
+Netherlands,2010,4.41
+Netherlands,2012,4.15
+Netherlands,2014,4.34
+Netherlands,2016,4.41
+Netherlands,2018,4.25
+Netherlands,2023,4.10
+New Zealand,2007,4.05
+New Zealand,2010,4.17
+New Zealand,2012,3.55
+New Zealand,2014,3.72
+New Zealand,2016,4.12
+New Zealand,2018,4.26
+New Zealand,2023,3.60
+Nicaragua,2007,2.50
+Nicaragua,2010,3.21
+Nicaragua,2014,3.17
+Nicaragua,2016,2.68
+Nicaragua,2023,2.50
+Niger,2007,3.00
+Niger,2010,3.28
+Niger,2012,3.07
+Niger,2014,2.76
+Niger,2016,3.02
+Niger,2018,2.33
+Nigeria,2007,2.69
+Nigeria,2010,3.10
+Nigeria,2012,2.92
+Nigeria,2014,3.46
+Nigeria,2016,3.04
+Nigeria,2018,3.07
+Nigeria,2023,2.60
+North Macedonia,2023,3.10
+Norway,2007,4.24
+Norway,2010,4.35
+Norway,2012,4.09
+Norway,2014,4.36
+Norway,2016,3.77
+Norway,2018,3.94
+Norway,2023,3.70
+Oman,2007,4.00
+Oman,2010,3.94
+Oman,2012,3.17
+Oman,2014,3.29
+Oman,2016,3.50
+Oman,2018,3.80
+Oman,2023,3.30
+Pakistan,2007,2.93
+Pakistan,2010,3.08
+Pakistan,2012,3.14
+Pakistan,2014,2.79
+Pakistan,2016,3.48
+Pakistan,2018,2.66
+Panama,2007,3.43
+Panama,2010,3.76
+Panama,2012,3.47
+Panama,2014,3.63
+Panama,2016,3.74
+Panama,2018,3.60
+Panama,2023,3.10
+Papua New Guinea,2007,3.14
+Papua New Guinea,2010,3.24
+Papua New Guinea,2012,3.01
+Papua New Guinea,2014,2.73
+Papua New Guinea,2016,2.78
+Papua New Guinea,2018,2.44
+Papua New Guinea,2023,2.70
+Paraguay,2007,3.23
+Paraguay,2010,3.46
+Paraguay,2012,2.74
+Paraguay,2014,3.22
+Paraguay,2016,2.93
+Paraguay,2018,3.45
+Paraguay,2023,2.70
+Peru,2007,3.00
+Peru,2010,3.38
+Peru,2012,3.40
+Peru,2014,3.30
+Peru,2016,3.23
+Peru,2018,3.45
+Peru,2023,3.00
+Philippines,2007,3.14
+Philippines,2010,3.83
+Philippines,2012,3.30
+Philippines,2014,3.07
+Philippines,2016,3.35
+Philippines,2018,2.98
+Philippines,2023,3.30
+Poland,2007,3.59
+Poland,2010,4.52
+Poland,2012,4.04
+Poland,2014,4.13
+Poland,2016,3.80
+Poland,2018,3.95
+Poland,2023,3.60
+Portugal,2007,4.06
+Portugal,2010,3.84
+Portugal,2012,3.88
+Portugal,2014,3.87
+Portugal,2016,3.95
+Portugal,2018,4.13
+Portugal,2023,3.40
+Qatar,2007,3.67
+Qatar,2010,4.09
+Qatar,2012,4.00
+Qatar,2014,3.87
+Qatar,2016,3.83
+Qatar,2018,3.70
+Qatar,2023,3.50
+Romania,2007,3.18
+Romania,2010,3.45
+Romania,2012,3.82
+Romania,2014,4.00
+Romania,2016,3.22
+Romania,2018,3.68
+Romania,2023,3.20
+Russian Federation,2007,2.94
+Russian Federation,2010,3.23
+Russian Federation,2012,3.02
+Russian Federation,2014,3.14
+Russian Federation,2016,3.15
+Russian Federation,2018,3.31
+Russian Federation,2023,2.60
+Rwanda,2007,2.38
+Rwanda,2010,2.05
+Rwanda,2012,2.76
+Rwanda,2014,3.34
+Rwanda,2016,3.35
+Rwanda,2018,3.35
+Rwanda,2023,2.80
+Sao Tome,2007,3.00
+Saudi Arabia,2007,3.65
+Saudi Arabia,2010,3.78
+Saudi Arabia,2012,3.76
+Saudi Arabia,2014,3.55
+Saudi Arabia,2016,3.53
+Saudi Arabia,2018,3.30
+Saudi Arabia,2023,3.40
+Sco Tomi and Principe,2012,2.78
+Sco Tomi and Principe,2014,2.77
+Senegal,2007,2.63
+Senegal,2010,3.52
+Senegal,2012,2.74
+Senegal,2014,2.53
+Senegal,2016,2.61
+Senegal,2018,2.52
+Serbia,2010,2.80
+Serbia,2012,3.14
+Serbia,2014,3.55
+Serbia,2016,3.23
+Serbia,2018,3.33
+Serbia,2023,2.80
+SerbiaMontenegro,2007,2.54
+Sierra Leone,2007,2.64
+Sierra Leone,2010,2.33
+Sierra Leone,2012,2.35
+Sierra Leone,2016,2.23
+Sierra Leone,2018,2.34
+Singapore,2007,4.53
+Singapore,2010,4.23
+Singapore,2012,4.39
+Singapore,2014,4.25
+Singapore,2016,4.40
+Singapore,2018,4.32
+Singapore,2023,4.30
+Slovak Republic,2007,3.26
+Slovak Republic,2010,3.92
+Slovak Republic,2012,3.57
+Slovak Republic,2014,3.94
+Slovak Republic,2016,3.81
+Slovak Republic,2018,3.14
+Slovak Republic,2023,3.30
+Slovenia,2007,3.73
+Slovenia,2010,3.10
+Slovenia,2012,3.60
+Slovenia,2014,3.82
+Slovenia,2016,3.47
+Slovenia,2018,3.70
+Slovenia,2023,3.30
+Solomon Islands,2007,2.30
+Solomon Islands,2010,3.05
+Solomon Islands,2012,3.04
+Solomon Islands,2014,2.96
+Solomon Islands,2016,2.76
+Solomon Islands,2018,3.12
+Solomon Islands,2023,2.80
+Somalia,2007,3.00
+Somalia,2010,1.38
+Somalia,2014,1.88
+Somalia,2016,2.35
+Somalia,2018,2.20
+Somalia,2023,2.00
+South Africa,2007,3.78
+South Africa,2010,3.57
+South Africa,2012,4.03
+South Africa,2014,3.88
+South Africa,2016,4.02
+South Africa,2018,3.74
+South Africa,2023,3.70
+South Korea,2007,3.86
+Spain,2007,3.86
+Spain,2010,4.12
+Spain,2012,4.02
+Spain,2014,4.07
+Spain,2016,4.00
+Spain,2018,4.06
+Spain,2023,3.90
+Sri Lanka,2007,2.69
+Sri Lanka,2010,2.98
+Sri Lanka,2012,2.90
+Sri Lanka,2014,3.12
+Sri Lanka,2018,2.79
+Sri Lanka,2023,2.80
+Sudan,2007,3.17
+Sudan,2010,3.09
+Sudan,2012,2.31
+Sudan,2014,2.33
+Sudan,2016,3.28
+Sudan,2018,2.62
+Sudan,2023,2.40
+Sweden,2007,4.43
+Sweden,2010,4.32
+Sweden,2012,4.26
+Sweden,2014,4.26
+Sweden,2016,4.45
+Sweden,2018,4.28
+Sweden,2023,4.00
+Switzerland,2007,4.48
+Switzerland,2010,4.20
+Switzerland,2012,4.01
+Switzerland,2014,4.06
+Switzerland,2016,4.24
+Switzerland,2018,4.24
+Switzerland,2023,4.10
+Syria,2007,2.67
+Syrian Arab Republic,2010,3.45
+Syrian Arab Republic,2012,3.26
+Syrian Arab Republic,2014,2.53
+Syrian Arab Republic,2016,2.40
+Syrian Arab Republic,2018,2.44
+Syrian Arab Republic,2023,2.30
+São Tomé and Principe,2016,2.75
+São Tomé and Principe,2018,3.01
+TC<rkiye,2023,3.40
+Taiwan,2010,3.95
+Taiwan,2012,4.10
+Taiwan,2014,4.02
+"Taiwan, China",2007,4.18
+"Taiwan, China",2016,4.25
+"Taiwan, China",2018,3.72
+"Taiwan, China",2023,3.90
+Tajikistan,2007,2.11
+Tajikistan,2010,3.16
+Tajikistan,2012,2.51
+Tajikistan,2014,2.74
+Tajikistan,2016,2.04
+Tajikistan,2018,2.95
+Tajikistan,2023,2.50
+Tanzania,2007,2.27
+Tanzania,2010,3.33
+Tanzania,2012,2.97
+Tanzania,2014,2.89
+Tanzania,2016,3.44
+Thailand,2007,3.91
+Thailand,2010,3.73
+Thailand,2012,3.63
+Thailand,2014,3.96
+Thailand,2016,3.56
+Thailand,2018,3.81
+Thailand,2023,3.50
+Timor-Leste,2007,2.25
+Togo,2007,2.11
+Togo,2010,3.02
+Togo,2012,2.77
+Togo,2014,2.60
+Togo,2016,3.24
+Togo,2018,2.88
+Togo,2023,2.50
+Trinidad and Tobago,2016,2.79
+Trinidad and Tobago,2018,2.53
+Trinidad and Tobago,2023,2.50
+Tunisia,2007,2.80
+Tunisia,2010,3.57
+Tunisia,2012,3.75
+Tunisia,2014,3.16
+Tunisia,2016,3.00
+Tunisia,2018,3.24
+Turkey,2007,3.38
+Turkey,2010,3.94
+Turkey,2012,3.87
+Turkey,2014,3.68
+Turkey,2016,3.75
+Turkey,2018,3.63
+Turkmenistan,2010,3.51
+Turkmenistan,2014,2.45
+Turkmenistan,2016,2.59
+Turkmenistan,2018,2.72
+Uganda,2007,3.29
+Uganda,2010,3.52
+Uganda,2016,3.70
+Uganda,2018,2.90
+Ukraine,2007,3.31
+Ukraine,2010,3.06
+Ukraine,2012,3.31
+Ukraine,2014,3.51
+Ukraine,2016,3.51
+Ukraine,2018,3.42
+Ukraine,2023,2.70
+United Arab Emirates,2007,4.12
+United Arab Emirates,2010,3.94
+United Arab Emirates,2012,4.10
+United Arab Emirates,2014,3.92
+United Arab Emirates,2016,4.13
+United Arab Emirates,2018,4.38
+United Arab Emirates,2023,4.00
+United Kingdom,2007,4.25
+United Kingdom,2010,4.37
+United Kingdom,2012,4.19
+United Kingdom,2014,4.33
+United Kingdom,2016,4.33
+United Kingdom,2018,4.33
+United Kingdom,2023,3.70
+United States,2007,4.11
+United States,2010,4.19
+United States,2012,4.21
+United States,2014,4.14
+United States,2016,4.25
+United States,2018,4.08
+United States,2023,3.80
+Uruguay,2007,3.00
+Uruguay,2010,3.06
+Uruguay,2012,3.16
+Uruguay,2014,3.06
+Uruguay,2016,3.47
+Uruguay,2018,2.91
+Uruguay,2023,3.00
+Uzbekistan,2007,2.73
+Uzbekistan,2010,3.72
+Uzbekistan,2012,2.96
+Uzbekistan,2014,3.08
+Uzbekistan,2016,2.83
+Uzbekistan,2018,3.09
+Uzbekistan,2023,2.60
+Venezuela,2007,3.03
+"Venezuela, RB",2010,3.05
+"Venezuela, RB",2012,3.18
+"Venezuela, RB",2014,3.18
+"Venezuela, RB",2016,2.71
+"Venezuela, RB",2018,2.58
+"Venezuela, RB",2023,2.30
+Vietnam,2007,3.22
+Vietnam,2010,3.44
+Vietnam,2012,3.64
+Vietnam,2014,3.49
+Vietnam,2016,3.50
+Vietnam,2018,3.67
+Vietnam,2023,3.30
+Yemen,2007,2.78
+"Yemen, Rep.",2010,3.48
+"Yemen, Rep.",2012,3.29
+"Yemen, Rep.",2014,2.78
+"Yemen, Rep.",2018,2.43
+"Yemen, Rep.",2023,2.20
+Zambia,2007,2.50
+Zambia,2010,2.85
+Zambia,2014,2.91
+Zambia,2016,2.74
+Zambia,2018,3.05
+Zimbabwe,2007,2.85
+Zimbabwe,2012,3.27
+Zimbabwe,2014,2.93
+Zimbabwe,2016,2.13
+Zimbabwe,2018,2.39
+Zimbabwe,2023,2.50


### PR DESCRIPTION
## Summary
- rework the LPI infrastructure conversion script to parse XLSX data without optional dependencies
- extract per-sheet country scores across all years and write the normalized CSV output
- reorder LPI infrastructure output to `country,year,value` and round values to two decimals using commercial rounding

## Testing
- python scripts/convert_lpi_infrastructure.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924496c4ab8832d983403bcb3d4ca72)